### PR TITLE
fix: Default frecency/history DB paths to ~/.pi/agent/fff/ (#474)

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -22,6 +22,8 @@ import type {
   MixedItem,
 } from "@ff-labs/fff-node";
 import { buildQuery } from "./query";
+import * as os from "os";
+import * as path from "path";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -301,15 +303,18 @@ export default function fffExtension(pi: ExtensionAPI) {
 
   const toolNames = resolveToolNames(currentMode);
 
-  // DB path resolution: flag > env > undefined (use fff-node defaults)
+  // Default storage under ~/.pi/agent/fff/ as documented in README
+  const defaultDbDir = path.join(os.homedir(), ".pi", "agent", "fff");
+
+  // DB path resolution: flag > env > default (~/.pi/agent/fff/)
   const frecencyDbPath =
     (pi.getFlag("fff-frecency-db") as string | undefined) ??
     process.env.FFF_FRECENCY_DB ??
-    undefined;
+    path.join(defaultDbDir, "frecency");
   const historyDbPath =
     (pi.getFlag("fff-history-db") as string | undefined) ??
     process.env.FFF_HISTORY_DB ??
-    undefined;
+    path.join(defaultDbDir, "history");
 
   function getMode(): FffMode {
     return currentMode;


### PR DESCRIPTION
Closes #474

## Root cause

`packages/pi-fff/src/index.ts:305-312` defaulted `frecencyDbPath` and `historyDbPath` to `undefined`. At the FFI boundary (`packages/fff-node/src/finder.ts:112-113`), `undefined` becomes empty string. In `crates/fff-c/src/lib.rs:210-211`, `optional_cstr("")` returns `None`. When `None`, frecency/query-tracker init skipped (lines 219-248), so both stay default uninitialized.

## Fix

Default both to `~/.pi/agent/fff/frecency` and `~/.pi/agent/fff/history`, matching README claim (line 152). Flag/env overrides unchanged.

## Steps to reproduce

**Pre-fix (main):**
```bash
# Install pi-fff without flags
pi install -l npm:@ff-labs/pi-fff

# Use fffind, select results
pi -c 'fffind main'

# Verify no LMDB created
ls ~/.pi/agent/fff/  # directory doesn't exist

# Check health
pi -c '/fff-health'  # shows "Frecency: disabled" and "Query tracker: disabled"
```

Expected: frecency/history active, LMDB files created under `~/.pi/agent/fff/`.
Actual: both disabled, no files created.

**Post-fix (this PR):**
```bash
# Same steps
pi install -l npm:@ff-labs/pi-fff
pi -c 'fffind main'
ls ~/.pi/agent/fff/  # frecency/ and history/ exist

# Check health
pi -c '/fff-health'  # shows "Frecency: active" and "Query tracker: active"
```

## How verified

- Reviewed diff: import statements added, default paths set before flag/env resolution.
- Checked `make lint`: no errors in pi-fff.
- Logic verified: `path.join(os.homedir(), ".pi", "agent", "fff")` constructs correct base, then `frecency` / `history` appended.
- Did not run live test (no pi install available in triage env), but logic straightforward: replaces `undefined` with concrete path.

Automated triage via gustav-fff bot.