### PR TITLE
fix(scan): pre-arm scanning flag before publishing reindexed picker

### DIFF
--- a/crates/fff-core/src/file_picker.rs
+++ b/crates/fff-core/src/file_picker.rs
@@ -761,6 +761,16 @@ impl FilePicker {
         let path = picker.base_path.clone();
         let trace_span = picker.trace_span.clone();
 
+        // Pre-arm `scanning` BEFORE publishing the new picker. `ScanJob::spawn`
+        // also sets it, but that runs after this function returns; consumers
+        // (e.g. lua `wait_for_initial_scan` after `restart_index_in_path`)
+        // that grab the signal Arc between publish and spawn would otherwise
+        // observe scanning=false and skip the wait, racing the walker. The
+        // race is wide on Windows CI where notify is slow.
+        signals
+            .scanning
+            .store(true, std::sync::atomic::Ordering::Release);
+
         {
             let mut guard = shared_picker.write()?;
             *guard = Some(picker);


### PR DESCRIPTION
Refs #552 (CI flake follow-up requested by @dmtrKovalenko).

## Root cause
`FilePicker::new_with_shared_state` (`crates/fff-core/src/file_picker.rs:736`) publishes the freshly built `FilePicker` to `SharedFilePicker` with `signals.scanning = false` (the `ScanSignals::default()` value at construction). The scanning flag is only flipped to `true` later, on the new OS thread inside `ScanJob::spawn` (`crates/fff-core/src/scan.rs:140`).

Between the publish and the spawn, any consumer that grabs a clone of `signals.scanning` from the picker — e.g. lua `wait_for_initial_scan` called right after `restart_index_in_path` reports the new `base_path` via `health_check` — observes `scanning=false` and returns immediately. A search issued right after then runs on the freshly-initialized, empty index (walker hasn't committed yet).

`tests/programmatic_search_spec.lua:212` ("content_search switches indexed root before grepping") hits exactly this sequence: write file, switch cwd, immediately grep. On Linux/macOS the walker is fast enough that the race rarely closes; on Windows CI the walker startup is slower and the test flakes.

## Fix
Set `scanning=true` on the cloned `signals` Arc **before** publishing the new picker into the shared lock. `ScanJob::spawn` still re-stores `true` so happy-path semantics are unchanged; the only new guarantee is that any wait obtaining the signal Arc post-publish observes scanning=true and waits for the walker.

Diff is 10 lines, no behavior change off the race path.

## Steps to reproduce
Manual: not easily on macOS/Linux — race is timing-dependent. CI: Windows e2e job consistently failed with the assertion below on PR #552 and on `main` (masked by `continue-on-error` on push).

```
D:/a/fff/fff/tests/programmatic_search_spec.lua:212: cwd switch did not surface match from the new root
Expected objects to be the same.
Passed in: (boolean) false
Expected: (boolean) true
```

## How verified
- `cargo check --workspace` passes.
- @dmtrKovalenko asked for ≥5 Windows CI re-runs on this PR before merge to confirm the flake is gone — opening as draft so the workflow runs and the result can be observed across multiple attempts.

Automated triage via Gustav. Honk-Honk 🪿