### PR TITLE
fix(pi-fff): non-blocking session_start warmup

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -285,6 +285,10 @@ export default function fffExtension(pi: ExtensionAPI) {
   // deadlock at the native layer (issue #403).
   let finderPromise: Promise<FileFinder> | null = null;
   let activeCwd = process.cwd();
+  // Bumped on every session_start / session_shutdown so an async warmup
+  // started for a previous session can detect that it's stale and bail out
+  // before touching `finder` / notifying a destroyed UI.
+  let lifecycleId = 0;
 
   // Mode resolution: flag > env > default
   let currentMode: FffMode =
@@ -355,10 +359,13 @@ export default function fffExtension(pi: ExtensionAPI) {
       if (!result.ok)
         throw new Error(`Failed to create FFF file finder: ${result.error}`);
 
-      finder = result.value;
+      const created = result.value;
+      finder = created;
       finderCwd = cwd;
-      await finder.waitForScan(15000);
-      return finder;
+      await created.waitForScan(15000);
+      // Return the local handle: a shutdown during warmup may null/replace
+      // `finder`, but the caller still needs the instance they were promised.
+      return created;
     })().finally(() => {
       finderPromise = null;
     });
@@ -467,6 +474,7 @@ export default function fffExtension(pi: ExtensionAPI) {
   pi.on("session_start", async (_event, ctx) => {
     try {
       activeCwd = ctx.cwd;
+      const sessionLifecycleId = ++lifecycleId;
 
       // Restore persisted mode from session entries. This handles session
       // resume after process restart where env vars are lost, and ensures
@@ -492,7 +500,20 @@ export default function fffExtension(pi: ExtensionAPI) {
       }
 
       registerAutocompleteProvider(ctx);
-      await ensureFinder(activeCwd);
+
+      // Warm the finder in the background — Pi /new and /resume must not
+      // wait on the initial scan. Subsequent tool calls / mention lookups
+      // share the same in-flight promise via ensureFinder().
+      setTimeout(() => {
+        if (sessionLifecycleId !== lifecycleId) return;
+        ensureFinder(activeCwd).catch((e: unknown) => {
+          if (sessionLifecycleId !== lifecycleId) return;
+          ctx.ui.notify(
+            `FFF init failed: ${e instanceof Error ? e.message : String(e)}`,
+            "error",
+          );
+        });
+      }, 0);
     } catch (e: unknown) {
       ctx.ui.notify(
         `FFF init failed: ${e instanceof Error ? e.message : String(e)}`,
@@ -502,6 +523,7 @@ export default function fffExtension(pi: ExtensionAPI) {
   });
 
   pi.on("session_shutdown", async () => {
+    lifecycleId++;
     destroyFinder();
   });
 

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -118,6 +118,10 @@ async function start(mode?: string) {
   const sessionStart = setup.events.get("session_start");
   expect(sessionStart).toBeDefined();
   await sessionStart?.({ reason: "startup" }, ctx);
+  // session_start now schedules the finder warmup via setTimeout(0); flush
+  // the queue so tests can observe FileFinder.create / waitForScan calls.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
 
   return { ...setup, ctx };
 }


### PR DESCRIPTION
Closes #477

## Root cause
`packages/pi-fff/src/index.ts` `session_start` handler awaited `ensureFinder()` → `finder.waitForScan(15000)`. Pi recreates the session runtime on `/new` and `/resume`, so the lifecycle hook blocked the UI until the FFF initial scan finished (up to 15s on large workspaces).

## Fix
- Schedule `ensureFinder(activeCwd)` from `session_start` via `setTimeout(0)` instead of awaiting it. The handler returns immediately; the warmup runs in the background.
- Track a monotonic `lifecycleId`, bumped on every `session_start` and `session_shutdown`. The deferred warmup checks the captured id and bails out (no `ensureFinder`, no `ctx.ui.notify`) if the session has been replaced.
- `ensureFinder` returns the local `created` handle instead of the mutable `finder` global, so a `destroyFinder()` racing the warmup cannot hand back a destroyed/replaced instance to the caller.

The native SDK already exposes `waitForScan` as a non-blocking polling loop (`packages/fff-node/src/finder.ts:477`), so no SDK changes were needed — only the lifecycle hook.

## Steps to reproduce
Pre-fix, on `main`:

```bash
git checkout main
cd packages/pi-fff
# Run pi with the extension installed against a large workspace (e.g. chromium / linux)
pi
# In pi: type /new and press Enter
```

Expected: new session is interactive immediately.
Actual (pre-fix): UI hangs for up to 15s while `FileFinder.create` + initial scan runs inside `session_start`. Same hang on `/resume` after picking a session.

Post-fix: `/new` and `/resume` return instantly. The first `ffgrep` / `fffind` / `@`-mention call awaits the same in-flight `ensureFinder` promise as before.

## How verified
- `bun test test/` in `packages/pi-fff` — all 17 tests pass (test helper updated to flush the deferred warmup before asserting).
- `tsc --noEmit` produces only the pre-existing module-resolution errors (unchanged from `main`).
- Manual code review of the lifecycle race: shutdown during warmup is safe because the deferred callback short-circuits on stale `lifecycleId`, and `ensureFinder` returns the local handle.

Automated triage via Gustav. Honk-Honk 🪿