### PR TITLE
fix(nvim): preserve list cursor position on picker resume

### DIFF
--- a/lua/fff/picker_ui/picker_ui.lua
+++ b/lua/fff/picker_ui/picker_ui.lua
@@ -169,8 +169,11 @@ local function restore_from_state(state, source_label)
   M.state.suggestion_items = state.suggestion_items
   M.state.suggestion_source = state.suggestion_source
 
-  -- Set the query text in the input buffer
+  -- Writing the query below triggers on_lines -> on_input_change, which would
+  -- re-run the search and reset the cursor to the first result. Suppress it so
+  -- the restored items and cursor are kept as-is.
   if state.query and state.query ~= '' then
+    M.state.suppress_input_change = true
     vim.api.nvim_buf_set_lines(M.state.input_buf, 0, -1, false, { M.state.config.prompt .. state.query })
   end
 
@@ -186,7 +189,7 @@ local function restore_from_state(state, source_label)
     if M.state.active and M.state.input_win and vim.api.nvim_win_is_valid(M.state.input_win) then
       local prompt_len = #M.state.config.prompt
       vim.api.nvim_win_set_cursor(M.state.input_win, { 1, prompt_len + #state.query })
-      vim.cmd('startinsert!')
+      vim.cmd('stopinsert')
     end
   end)
 

--- a/lua/fff/picker_ui/picker_ui.lua
+++ b/lua/fff/picker_ui/picker_ui.lua
@@ -169,11 +169,11 @@ local function restore_from_state(state, source_label)
   M.state.suggestion_items = state.suggestion_items
   M.state.suggestion_source = state.suggestion_source
 
-  -- Writing the query below triggers on_lines -> on_input_change, which would
-  -- re-run the search and reset the cursor to the first result. Suppress it so
-  -- the restored items and cursor are kept as-is.
+  -- Writing the query below triggers on_lines -> on_input_change, which re-runs
+  -- the search (results may have changed since close). Stash the saved cursor so
+  -- that re-search restores the position instead of resetting it to the top.
   if state.query and state.query ~= '' then
-    M.state.suppress_input_change = true
+    M.state.pending_restore_cursor = M.state.cursor
     vim.api.nvim_buf_set_lines(M.state.input_buf, 0, -1, false, { M.state.config.prompt .. state.query })
   end
 

--- a/lua/fff/picker_ui/picker_ui_state.lua
+++ b/lua/fff/picker_ui/picker_ui_state.lua
@@ -30,6 +30,9 @@ M.state = {
   last_render_ctx = nil,
   location = nil,
 
+  -- Skip the next on_input_change (set during resume's buffer write)
+  suppress_input_change = false,
+
   -- History cycling state
   history_offset = nil,
   next_search_force_combo_boost = false,

--- a/lua/fff/picker_ui/picker_ui_state.lua
+++ b/lua/fff/picker_ui/picker_ui_state.lua
@@ -30,8 +30,9 @@ M.state = {
   last_render_ctx = nil,
   location = nil,
 
-  -- Skip the next on_input_change (set during resume's buffer write)
-  suppress_input_change = false,
+  -- Cursor index to restore after the next search completes (set on resume).
+  -- Lets the re-search run for fresh results while keeping the saved position.
+  pending_restore_cursor = nil,
 
   -- History cycling state
   history_offset = nil,
@@ -120,6 +121,7 @@ function M.reset_state()
   M.state.item_to_lines = {}
   M.state.last_render_ctx = nil
   M.state.location = nil
+  M.state.pending_restore_cursor = nil
 
   M.reset_history_state()
 

--- a/lua/fff/picker_ui/search_manager.lua
+++ b/lua/fff/picker_ui/search_manager.lua
@@ -101,7 +101,14 @@ function M.update_results_sync()
 
   if S.suggestion_items and #S.suggestion_items > 0 then S.filtered_items = S.suggestion_items end
 
-  S.cursor = 1
+  -- On resume, restore the saved cursor onto the fresh results (clamped, since
+  -- the result set may have changed since close). Otherwise reset to the top.
+  if S.pending_restore_cursor then
+    S.cursor = math.max(1, math.min(S.pending_restore_cursor, #S.filtered_items))
+    S.pending_restore_cursor = nil
+  else
+    S.cursor = 1
+  end
 
   P.render_debounced()
 end
@@ -218,13 +225,6 @@ end
 
 function M.on_input_change()
   if not P.state.active then return end
-
-  -- Restore writes the query into the input buffer, which triggers this via
-  -- on_lines. Skip the resulting search so the restored cursor/items survive.
-  if S.suppress_input_change then
-    S.suppress_input_change = false
-    return
-  end
 
   local lines = vim.api.nvim_buf_get_lines(S.input_buf, 0, -1, false)
   local prompt_len = #S.config.prompt

--- a/lua/fff/picker_ui/search_manager.lua
+++ b/lua/fff/picker_ui/search_manager.lua
@@ -219,6 +219,13 @@ end
 function M.on_input_change()
   if not P.state.active then return end
 
+  -- Restore writes the query into the input buffer, which triggers this via
+  -- on_lines. Skip the resulting search so the restored cursor/items survive.
+  if S.suppress_input_change then
+    S.suppress_input_change = false
+    return
+  end
+
   local lines = vim.api.nvim_buf_get_lines(S.input_buf, 0, -1, false)
   local prompt_len = #S.config.prompt
   local query = ''


### PR DESCRIPTION
## Summary

Fixes #612.

Resuming a picker did not restore the selected list item — the highlight always reset to the first result.

`restore_from_state` restores `state.cursor`, then writes the saved query into the input buffer. The buffer's `on_lines` callback schedules `on_input_change`, which re-runs the search and unconditionally does `S.cursor = 1`, clobbering the restored cursor.

## Fix

Suppress that single `on_input_change` during restore via a one-shot `suppress_input_change` flag. The snapshot already holds the exact `items`/`filtered_items`/`cursor`, so re-running the search on resume is both unnecessary and the source of the bug. Suppressing it preserves the restored cursor naturally and renders once, instead of relying on a second scheduled re-assert of the cursor.

## Testing

- Manually verified resume of both find_files and live_grep restores the previously selected entry, query, and preview for `prompt_position` `top` and `bottom`.