### PR TITLE
fix(nvim): keep prompt icon when clearing input with cc/S

### DIFF
--- a/lua/fff/picker_ui/ui_creator.lua
+++ b/lua/fff/picker_ui/ui_creator.lua
@@ -357,6 +357,22 @@ function M.setup_keymaps()
   if S.config.prompt_vim_mode then
     set_keymap('n', keymaps.close, P.close, input_opts)
     set_keymap('i', '<C-c>', P.close, input_opts)
+
+    -- cc/S clear the whole line, wiping the prompt buffer's prompt and leaving
+    -- a stray icon behind. Reset to just the prompt and re-enter insert instead.
+    local function clear_query_line()
+      local prompt = S.config.prompt
+      vim.api.nvim_set_option_value('modifiable', true, { buf = S.input_buf })
+      vim.api.nvim_buf_set_lines(S.input_buf, 0, -1, false, { prompt })
+      vim.schedule(function()
+        if S.input_win and vim.api.nvim_win_is_valid(S.input_win) then
+          vim.api.nvim_win_set_cursor(S.input_win, { 1, #prompt })
+          vim.cmd('startinsert!')
+        end
+      end)
+    end
+    set_keymap('n', 'cc', clear_query_line, input_opts)
+    set_keymap('n', 'S', clear_query_line, input_opts)
   else
     set_keymap({ 'i', 'n' }, keymaps.close, P.close, input_opts)
   end

--- a/lua/fff/picker_ui/ui_creator.lua
+++ b/lua/fff/picker_ui/ui_creator.lua
@@ -371,8 +371,10 @@ function M.setup_keymaps()
         end
       end)
     end
-    set_keymap('n', 'cc', clear_query_line, input_opts)
-    set_keymap('n', 'S', clear_query_line, input_opts)
+    -- remap=true so existing user mappings of cc/S still resolve
+    local clear_opts = vim.tbl_extend('force', input_opts, { noremap = false, remap = true })
+    set_keymap('n', 'cc', clear_query_line, clear_opts)
+    set_keymap('n', 'S', clear_query_line, clear_opts)
   else
     set_keymap({ 'i', 'n' }, keymaps.close, P.close, input_opts)
   end


### PR DESCRIPTION
## Summary

Fixes #614.

With `prompt_vim_mode = true`, clearing the query from normal mode with `cc`/`S` left a stray prompt icon behind that had to be backspaced out.

The input bar is a `buftype=prompt` buffer whose prompt icon is protected text at the start of the line. `cc`/`S` delete the whole line including the prompt, so Neovim re-inserts the icon as plain literal text.

## Fix

In `prompt_vim_mode`, map `cc` and `S` to reset the line to just the prompt and re-enter insert at the correct column. Clearing the query now leaves the prompt intact, and the resulting empty-query search runs as normal.

## Testing

- Manually verified `cc` and `S` from normal mode in `prompt_vim_mode` clear the query and keep the prompt icon, with the cursor placed right after it in insert mode.