### PR TITLE
fix(download): fall back to nearest ancestor tag when HEAD is untagged

### DIFF
--- a/lua/fff/download.lua
+++ b/lua/fff/download.lua
@@ -182,8 +182,18 @@ function M.ensure_downloaded(opts, callback)
       return
     end
 
-    -- 2. No local tag — construct the nightly version (bumps patch so
-    --    the prerelease is higher than Cargo.toml base in semver)
+    -- 2. HEAD has no tag — fall back to the nearest ancestor's published release
+    --    tag. This covers `[skip ci]` commits on `main` (e.g. the post-release
+    --    Cargo.toml bump) which never get their own nightly published, so the
+    --    synthesised `{base+1}-nightly.{HEAD-sha}` tag from resolve() 404s.
+    local ancestor_tag = fff_version.nearest_ancestor_release_tag(repo_root)
+    if ancestor_tag then
+      on_release_tag(ancestor_tag)
+      return
+    end
+
+    -- 3. No ancestor tag found either — synthesise the nightly version (bumps
+    --    patch so the prerelease is higher than Cargo.toml base in semver).
     local info, err = fff_version.resolve(repo_root)
     if info then
       on_release_tag(info.release_tag)

--- a/lua/fff/utils/version.lua
+++ b/lua/fff/utils/version.lua
@@ -56,6 +56,22 @@ function M.current_release_tag(repo_root)
   return stable or nightly_versioned or dev or other or nightly_alias
 end
 
+--- Find the nearest ancestor commit that owns a downloadable release tag.
+--- Used as a fallback when HEAD itself has no tag (e.g. a `[skip ci]` bump
+--- commit on `main`) — without it, `resolve()` synthesises a per-sha nightly
+--- tag for HEAD that has no published release and the binary download 404s.
+---@param repo_root string
+---@return string|nil tag
+function M.nearest_ancestor_release_tag(repo_root)
+  local stable = git(repo_root, 'describe', '--tags', '--abbrev=0', '--match', 'v*', 'HEAD')
+  if stable and stable:match('^v%d') then return stable end
+
+  local nightly = git(repo_root, 'describe', '--tags', '--abbrev=0', '--match', '*-nightly.*', 'HEAD')
+  if nightly and nightly:match('%-nightly%.') then return nightly end
+
+  return nil
+end
+
 function M.read_base_version(repo_root)
   local cargo_path = repo_root .. '/crates/fff-core/Cargo.toml'
   local f = io.open(cargo_path, 'r')

--- a/tests/version_spec.lua
+++ b/tests/version_spec.lua
@@ -113,6 +113,76 @@ describe('fff.utils.version', function()
     end)
   end)
 
+  describe('nearest_ancestor_release_tag', function()
+    it('should fall back to nearest stable tag when HEAD is untagged', function()
+      local tmp = vim.fn.tempname()
+      vim.fn.mkdir(tmp, 'p')
+
+      vim.fn.system({ 'git', 'init', '-q', tmp })
+      vim.fn.system({ 'git', '-C', tmp, 'config', 'user.email', 'test@test.com' })
+      vim.fn.system({ 'git', '-C', tmp, 'config', 'user.name', 'Test' })
+
+      local f = io.open(tmp .. '/file.txt', 'w')
+      f:write('one')
+      f:close()
+      vim.fn.system({ 'git', '-C', tmp, 'add', '.' })
+      vim.fn.system({ 'git', '-C', tmp, 'commit', '-q', '-m', 'one' })
+      vim.fn.system({ 'git', '-C', tmp, 'tag', 'v0.1.0' })
+
+      f = io.open(tmp .. '/file.txt', 'w')
+      f:write('two')
+      f:close()
+      vim.fn.system({ 'git', '-C', tmp, 'add', '.' })
+      vim.fn.system({ 'git', '-C', tmp, 'commit', '-q', '-m', 'two' })
+
+      assert.are.equal('v0.1.0', version.nearest_ancestor_release_tag(tmp))
+      vim.fn.delete(tmp, 'rf')
+    end)
+
+    it('should fall back to nightly tag when no stable ancestor exists', function()
+      local tmp = vim.fn.tempname()
+      vim.fn.mkdir(tmp, 'p')
+
+      vim.fn.system({ 'git', 'init', '-q', tmp })
+      vim.fn.system({ 'git', '-C', tmp, 'config', 'user.email', 'test@test.com' })
+      vim.fn.system({ 'git', '-C', tmp, 'config', 'user.name', 'Test' })
+
+      local f = io.open(tmp .. '/file.txt', 'w')
+      f:write('one')
+      f:close()
+      vim.fn.system({ 'git', '-C', tmp, 'add', '.' })
+      vim.fn.system({ 'git', '-C', tmp, 'commit', '-q', '-m', 'one' })
+      vim.fn.system({ 'git', '-C', tmp, 'tag', '0.1.0-nightly.aaaaaaa' })
+
+      f = io.open(tmp .. '/file.txt', 'w')
+      f:write('two')
+      f:close()
+      vim.fn.system({ 'git', '-C', tmp, 'add', '.' })
+      vim.fn.system({ 'git', '-C', tmp, 'commit', '-q', '-m', 'two' })
+
+      assert.are.equal('0.1.0-nightly.aaaaaaa', version.nearest_ancestor_release_tag(tmp))
+      vim.fn.delete(tmp, 'rf')
+    end)
+
+    it('should return nil for a repo with no release tags', function()
+      local tmp = vim.fn.tempname()
+      vim.fn.mkdir(tmp, 'p')
+
+      vim.fn.system({ 'git', 'init', '-q', tmp })
+      vim.fn.system({ 'git', '-C', tmp, 'config', 'user.email', 'test@test.com' })
+      vim.fn.system({ 'git', '-C', tmp, 'config', 'user.name', 'Test' })
+
+      local f = io.open(tmp .. '/file.txt', 'w')
+      f:write('hello')
+      f:close()
+      vim.fn.system({ 'git', '-C', tmp, 'add', '.' })
+      vim.fn.system({ 'git', '-C', tmp, 'commit', '-q', '-m', 'init' })
+
+      assert.is_nil(version.nearest_ancestor_release_tag(tmp))
+      vim.fn.delete(tmp, 'rf')
+    end)
+  end)
+
   describe('resolve', function()
     it('should resolve a version from the real repo', function()
       local info, err = version.resolve(repo_root)


### PR DESCRIPTION
Closes #623

## Root cause

`lua/fff/download.lua` resolves the download URL from local git state, not the latest GitHub release. When HEAD has no tag (e.g. the post-release `chore: bump fff-mcp release artifacts to vX.Y.Z [skip ci]` commit on `main`), `version.resolve()` synthesises `{base+1}-nightly.{HEAD-sha}` — but `[skip ci]` skipped the publish workflow for that commit, so no release with that tag exists. Result: 404 for anyone whose Lazy lockfile points at that commit.

Reproduced against `a39fec7` (current `main` HEAD):

```
$ curl -sLI -o /dev/null -w '%{http_code}\n' https://github.com/dmtrKovalenko/fff.nvim/releases/download/0.9.7-nightly.a39fec7/x86_64-unknown-linux-gnu.so
404
$ curl -sLI -o /dev/null -w '%{http_code}\n' https://github.com/dmtrKovalenko/fff.nvim/releases/download/0.9.7-nightly.28321da/x86_64-unknown-linux-gnu.so
200   # parent commit, has nightly release
```

## Fix

Add `version.nearest_ancestor_release_tag()` (uses `git describe --tags --abbrev=0`) and slot it between the existing `current_release_tag` and `resolve()` paths in `download.lua`:

1. tag on HEAD → use it (unchanged)
2. **NEW:** nearest ancestor stable (`v*`) tag, then nearest ancestor `*-nightly.*` tag
3. fall back to synthesised version (unchanged)

The ancestor commit owns a real published release with built binaries, so the download succeeds. Stable preferred over nightly so users get the most recent shipped version, not a rolling prerelease.

## Steps to reproduce

Pre-fix repro on `main` at `a39fec7`:

```sh
git clone git@github.com:dmtrKovalenko/fff.nvim.git /tmp/fff-repro
cd /tmp/fff-repro
git checkout a39fec7
nvim --headless -u NONE -c 'set rtp+=.' -c 'lua require("fff.download").download_or_build_binary()' -c 'q' 2>&1
# Expected (pre-fix): "Error downloading binary: Failed to download: curl: (22) ... 404 ... Trying cargo build --release"
# Expected (post-fix): downloads v0.9.6 binary successfully
```

## How verified

- All 16 cases in `tests/version_spec.lua` pass, including 3 new cases for `nearest_ancestor_release_tag` (stable preferred, nightly fallback, nil when no tags).
- Manual: `git describe --tags --abbrev=0 --match 'v*' HEAD` on `triage-bot/issue-623` (branched from `a39fec7`) returns `v0.9.6`, which has a published release.

Automated triage via Gustav. Honk-Honk 🪿