### PR TITLE
fix: read grep content into an owned buffer to avoid SIGBUS on concurrent file modification

### DIFF
--- a/crates/fff-core/src/case_insensitive_memmem.rs
+++ b/crates/fff-core/src/case_insensitive_memmem.rs
@@ -583,6 +583,54 @@ mod tests {
     }
 
     #[test]
+    fn guard_page_no_overread() {
+        // Place each haystack so it ENDS exactly at a PROT_NONE guard page; any
+        // SIMD load reading >=1 byte past the haystack end faults. This is the
+        // necessary condition for the production mmap'd-file SIGBUS.
+        unsafe {
+            let page = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+            let total = page * 2;
+            let base = libc::mmap(
+                std::ptr::null_mut(),
+                total,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_ANON | libc::MAP_PRIVATE,
+                -1,
+                0,
+            ) as *mut u8;
+            assert_ne!(base as isize, -1, "mmap failed");
+            assert_eq!(
+                libc::mprotect(base.add(page) as *mut _, page, libc::PROT_NONE),
+                0,
+                "mprotect failed"
+            );
+            let filler = b"the quick brown fox jumps over a lazy dog while searching files";
+            for i in 0..page {
+                *base.add(i) = filler[i % filler.len()];
+            }
+            for hlen in 1..=600usize {
+                let start = base.add(page - hlen);
+                let hay = std::slice::from_raw_parts(start, hlen);
+                let maxn = core::cmp::min(48, hlen);
+                for nlen in 2..=maxn {
+                    // (a) needle == haystack tail → match at the very end, so
+                    //     verify runs at candidate==last_start near the boundary.
+                    let mut needle = vec![0u8; nlen];
+                    for k in 0..nlen {
+                        needle[k] = ascii_fold_byte(*start.add(hlen - nlen + k));
+                    }
+                    let _ = search_packed_pair(hay, &needle);
+                    // (b) no-match needle → SIMD scans the whole haystack.
+                    let mut nope = needle.clone();
+                    nope[nlen - 1] = b'~';
+                    let _ = search_packed_pair(hay, &nope);
+                }
+            }
+            libc::munmap(base as *mut _, total);
+        }
+    }
+
+    #[test]
     fn packed_pair_matches_search() {
         let haystacks: &[&[u8]] = &[
             b"The quick brown fox jumps over the lazy dog",

--- a/crates/fff-core/src/case_insensitive_memmem.rs
+++ b/crates/fff-core/src/case_insensitive_memmem.rs
@@ -582,6 +582,7 @@ mod tests {
         assert!(!search_packed_pair(b"", b"x"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn guard_page_no_overread() {
         // Place each haystack so it ENDS exactly at a PROT_NONE guard page; any

--- a/crates/fff-core/src/types.rs
+++ b/crates/fff-core/src/types.rs
@@ -711,22 +711,21 @@ impl FileItem {
 
         // Read the file into an owned, reusable buffer rather than mmap it.
         //
-        // mmap-backed grep races with concurrent modification: if the file is
-        // truncated or rewritten while a mapping is live (an editor or coding
-        // agent changing the workspace), the pages past the new EOF become
-        // invalid and the next read — including a SIMD prefilter load over the
-        // whole file — faults with SIGBUS, aborting the entire process. The old
-        // cached fast path made it worse: an `OnceLock<Mmap>` created at index
-        // time could be served long after the file changed on disk. An owned
-        // read() copy is immune; a shrinking file just yields a shorter buffer,
-        // never a fault. `buf` is a per-worker scratch Vec reused across files,
-        // so this is one bounded copy per file, not a per-query allocation. (The
-        // content cache stays warm for the file picker via `get_cached_content`;
-        // only the grep reader stopped trusting a possibly-stale mapping.)
+        // Read into a reusable owned buffer, not mmap: an mmap'd file that is
+        // truncated/rewritten mid-grep (editor or agent edits) faults with
+        // SIGBUS on the pages past its new EOF. `buf` is per-worker, reused.
         let _ = mmap_slot;
-        let mut file = std::fs::File::open(&abs).ok()?;
+        let file = std::fs::File::open(&abs).ok()?;
         buf.clear();
-        file.read_to_end(buf).ok()?;
+        // Cap the read at the budget: `self.size` is the stale indexed size, so
+        // a file that GREW past `max_file_size` since indexing must not balloon
+        // memory. Read one byte over the cap and bail if it exceeds it.
+        file.take(max_file_size.saturating_add(1))
+            .read_to_end(buf)
+            .ok()?;
+        if buf.len() as u64 > max_file_size {
+            return None;
+        }
         Some(buf.as_slice())
     }
 }

--- a/crates/fff-core/src/types.rs
+++ b/crates/fff-core/src/types.rs
@@ -5,7 +5,7 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicI32, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 
 #[cfg(not(target_os = "windows"))]
-use crate::constants::{FRESH_MMAP_THRESHOLD, MMAP_THRESHOLD};
+use crate::constants::MMAP_THRESHOLD;
 use crate::constants::{MAX_CACHED_CONTENT_BYTES, MAX_FFFILE_SIZE, PATH_BUF_SIZE};
 use crate::constraints::Constrainable;
 use crate::query_tracker::QueryMatchEntry;
@@ -702,16 +702,6 @@ impl FileItem {
         base_path: &Path,
         budget: &ContentCacheBudget,
     ) -> Option<&'a [u8]> {
-        #[cfg(not(target_os = "windows"))]
-        {
-            // Fast path: persistent cache hit (zero-copy). Safe here because
-            // grep callers hold the picker read lock for the lifetime of the
-            // returned slice — see [`Self::get_cached_content`] safety note.
-            if let Some(cached) = self.get_cached_content(arena, base_path, budget) {
-                return Some(cached);
-            }
-        }
-
         let max_file_size = budget.max_file_size;
         if self.is_binary() || self.size == 0 || self.size > max_file_size {
             return None;
@@ -719,21 +709,24 @@ impl FileItem {
 
         let abs = self.absolute_path(arena, base_path);
 
-        #[cfg(not(target_os = "windows"))]
-        if self.size >= FRESH_MMAP_THRESHOLD {
-            let file = std::fs::File::open(&abs).ok()?;
-            let mmap = unsafe { memmap2::Mmap::map(&file) }.ok()?;
-            let stored = mmap_slot.insert(mmap);
-            return Some(&stored[..]);
-        } else {
-            let _ = (mmap_slot, arena);
-        }
-
-        let len = self.size as usize;
-        buf.resize(len, 0);
-
+        // Read the file into an owned, reusable buffer rather than mmap it.
+        //
+        // mmap-backed grep races with concurrent modification: if the file is
+        // truncated or rewritten while a mapping is live (an editor or coding
+        // agent changing the workspace), the pages past the new EOF become
+        // invalid and the next read — including a SIMD prefilter load over the
+        // whole file — faults with SIGBUS, aborting the entire process. The old
+        // cached fast path made it worse: an `OnceLock<Mmap>` created at index
+        // time could be served long after the file changed on disk. An owned
+        // read() copy is immune; a shrinking file just yields a shorter buffer,
+        // never a fault. `buf` is a per-worker scratch Vec reused across files,
+        // so this is one bounded copy per file, not a per-query allocation. (The
+        // content cache stays warm for the file picker via `get_cached_content`;
+        // only the grep reader stopped trusting a possibly-stale mapping.)
+        let _ = mmap_slot;
         let mut file = std::fs::File::open(&abs).ok()?;
-        file.read_exact(buf).ok()?;
+        buf.clear();
+        file.read_to_end(buf).ok()?;
         Some(buf.as_slice())
     }
 }

--- a/crates/fff-core/tests/grep_integration.rs
+++ b/crates/fff-core/tests/grep_integration.rs
@@ -1835,3 +1835,49 @@ fn plain_text_smart_case_finds_uppercase_content_with_lowercase_query() {
         "lowercase query should case-insensitively match 'VFIO-KVM'"
     );
 }
+
+/// Regression: grep must read the CURRENT file content even when the file was
+/// rewritten after indexing.
+///
+/// Grep used to read file content through an mmap — both a per-`FileItem`
+/// `OnceLock<Mmap>` cache and a fresh mmap for large files. When an editor or
+/// coding agent rewrites a file between greps (the common case for fff's nvim
+/// picker / MCP agent), reading it back through the stale/now-shorter mapping
+/// either returns stale matches or, once the file shrinks past a page boundary,
+/// faults with SIGBUS and aborts the whole host process. Reading grep content
+/// into an owned buffer fixes both: a changed file simply yields its new bytes.
+#[test]
+fn grep_reflects_file_rewrite_without_stale_mmap() {
+    let tmp = TempDir::new().unwrap();
+    let full = tmp.path().join("big.txt");
+
+    // Large enough to take the mmap path (> FRESH_MMAP_THRESHOLD), needle first.
+    let filler = "lorem ipsum dolor sit amet consectetur\n".repeat(60_000); // ~2.3 MB
+    fs::write(&full, format!("NEEDLE_TOKEN\n{filler}")).unwrap();
+
+    let mut picker = FilePicker::new(FilePickerOptions {
+        base_path: tmp.path().to_string_lossy().to_string(),
+        enable_mmap_cache: true, // exercise the cached-mmap path
+        watch: false,
+        ..Default::default()
+    })
+    .expect("Failed to create FilePicker");
+    picker.collect_files().expect("Failed to collect files");
+
+    let q = parse_grep_query("NEEDLE_TOKEN");
+    // First grep matches (and, on the old code, caches an mmap of the file).
+    assert_eq!(picker.grep(&q, &plain_opts()).matches.len(), 1);
+
+    // The file is rewritten much SHORTER with the needle removed — exactly what
+    // an editor / coding agent does mid-session. No re-index (`collect_files`).
+    fs::write(&full, "tiny replacement, no token here\n").unwrap();
+
+    // The second grep must reflect the NEW content: zero matches. The old reader
+    // returned the stale cached match (== 1) or SIGBUS-aborted on the shrunk
+    // mapping; both fail this assertion.
+    assert_eq!(
+        picker.grep(&q, &plain_opts()).matches.len(),
+        0,
+        "grep returned stale content from a cached mmap after the file changed"
+    );
+}


### PR DESCRIPTION
## Problem

Grep can **SIGBUS and abort the entire host process** when a file is modified while it is being searched.

`FileItem::get_content_for_search` returns file content via **mmap** — a per-`FileItem` `OnceLock<Mmap>` cache, plus a fresh mmap for files `>= FRESH_MMAP_THRESHOLD` (introduced in #533). mmap-backed reads are unsound under concurrent modification: when an editor or a coding agent rewrites/truncates a file **between or during** greps — the normal case for the Neovim picker and the MCP agent — the mapping's pages past the new EOF become invalid, and the next read (including the SIMD prefilter `case_insensitive_memmem::search_packed_pair` scanning the whole file) faults with `SIGBUS`, killing the process. A `SIGBUS` from an invalid mapping cannot be caught from safe Rust, so there is no recovery.

The cached mapping makes it worse: an `OnceLock<Mmap>` created at index time can be served long after the file changed on disk.

This surfaced in production as:

```
SIGBUS (0xa) ...
C  [libfff_c.dylib]  fff_search::case_insensitive_memmem::search_packed_pair
C  [libfff_c.dylib]  fff_search::grep::grep_search
```

## Root cause, not the search kernel

To rule out a real over-read in the SIMD memmem, I added a **guard-page unit test** (`case_insensitive_memmem::tests::guard_page_no_overread`): it places haystacks ending exactly at a `PROT_NONE` page and fuzzes lengths 1..600 × needle 2..48. It passes — the kernel never reads past a valid slice. **The fault is the invalid mapping, not the search.**

## Fix

Read grep content into the existing per-worker scratch `Vec<u8>` instead of mmap-ing it. The buffer is reused across files (one bounded copy per file, no per-query allocation) and is immune to truncation — a shrinking file simply yields its new, shorter bytes.

## Reproduction (deterministic)

Added `grep_reflects_file_rewrite_without_stale_mmap`: index a ~2 MB file, grep it, rewrite it much shorter with the needle removed (no re-index), grep again.

- **Before:** the second grep returns the stale cached match, or — once the file shrinks past a page boundary — aborts with `process didn't exit successfully ... (signal: 10, SIGBUS: access to undefined memory)`.
- **After:** the grep correctly reflects the new content (0 matches).

## Tradeoff

Grep content is no longer zero-copy mmap. If the repeatable-large-file perf from #533 matters, the cache could instead hold an owned `Box<[u8]>` (read once, invalidated when the file's size/mtime changes) — same speedup, still crash-safe. Happy to follow up that way if you prefer.

## Tests

- `cargo test -p fff-search` — all green (94 lib + integration), including the new regression and guard-page tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)