### PR TITLE
fix(preview): drop vim.pesc on grep highlight needle (#630)

### DIFF
--- a/lua/fff/location_utils.lua
+++ b/lua/fff/location_utils.lua
@@ -202,9 +202,13 @@ function M.highlight_grep_matches(bufnr, location, namespace)
 
   if not search_text or search_text == '' then return nil end
 
-  -- Build case-insensitive pattern if the query has no uppercase (smart case)
+  -- Build case-insensitive pattern if the query has no uppercase (smart case).
+  -- No vim.pesc: string.find below uses plain=true (4th arg), which treats the
+  -- needle as a literal byte sequence. Escaping here would turn `.` into `%.`
+  -- and then plain search would look for the literal two bytes `%.`, missing
+  -- every real `.` in content. Same for any other Lua-pattern metachar.
   local has_upper = search_text:match('[A-Z]')
-  local escaped = vim.pesc(search_text)
+  local needle = search_text
 
   -- Highlight pattern occurrences in a window around the target line.
   -- Limit to ±200 lines from target to keep it fast for large files.
@@ -218,7 +222,7 @@ function M.highlight_grep_matches(bufnr, location, namespace)
   for idx, line in ipairs(lines) do
     local i = scan_start + idx - 1
     local search_line = has_upper and line or line:lower()
-    local search_pat = has_upper and escaped or escaped:lower()
+    local search_pat = has_upper and needle or needle:lower()
     local start_pos = 1
     while true do
       local s, e = search_line:find(search_pat, start_pos, true)


### PR DESCRIPTION
Closes #630

## Root cause

`lua/fff/location_utils.lua:207` runs `vim.pesc(search_text)` on the grep needle before scanning preview lines, but the scanner at `lua/fff/location_utils.lua:224` calls `string.find(search_line, search_pat, start_pos, true)` with `plain=true`. With `plain=true` the needle is treated as a literal byte sequence, so the escape turns `.` into `%.` and the scanner then looks for the two literal bytes `%` `.` in content — which never appears in normal source code. Same failure mode for every other Lua-pattern metachar (`-`, `(`, `)`, `+`, `*`, `?`, `[`, `]`, `^`, `$`, `%`). Single-word queries without metachars look fine, multi-word queries that happen to contain a `.` (e.g. file extensions, version strings, member access) lose preview highlighting entirely.

## Fix

Drop `vim.pesc`. Pass the raw needle into `string.find(..., true)` directly. Smart-case lowering is preserved.

## Steps to reproduce

```sh
git checkout origin/main
nvim ~/some/repo
```

Inside Neovim:

1. `:lua require('fff').find_files()` then toggle to grep mode (default `<C-g>`), submode `plain` or `regex`.
2. Type a query containing a `.`, e.g. `foo.bar` or `1.0` or `vim.api`.
3. Move cursor to a result whose preview line contains the literal string.

Expected: every occurrence of `foo.bar` in the preview window is highlighted with `IncSearch`.
Actual: no preview highlights at all (the list row itself still shows the match because that path goes through Rust's `match_byte_offsets`, not this Lua scanner).

A single-token query without metachars (e.g. `foo`) highlights correctly, confirming the path works and only the escaping is wrong.

## How verified

- Read the scan loop: `string.find(search_line, search_pat, start_pos, true)` — the 4th argument is `plain`, which per Lua docs causes the pattern to be treated literally. Combined with `vim.pesc`, every metachar yields a needle that cannot match real content.
- Manual repro in nvim with query `vim.api` on this repo, pre-fix: no preview highlights. Post-fix: all `vim.api` occurrences in the visible preview window highlighted.

Automated triage via Gustav. Honk-Honk 🪿