### PR TITLE
feat(nvim): add layout.border to override winborder

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ require('fff').setup({
     prompt_position = 'bottom',   -- or 'top'
     preview_position = 'right',   -- 'left' | 'right' | 'top' | 'bottom'
     preview_size = 0.5,
+    -- Border style for the picker windows. Leave unset (nil) to follow the
+    -- global `vim.o.winborder`; set it to override fff's borders independently.
+    border = nil, -- 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'none'
     flex = { size = 130, wrap = 'top' },
     min_list_height = 10, --  do not display anything except the list below this threshold
     show_scrollbar = true,

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -9,6 +9,7 @@ local M = {}
 --- @field min_list_height number
 --- @field show_scrollbar boolean
 --- @field path_shorten_strategy string
+--- @field border? 'single'|'double'|'rounded'|'solid'|'shadow'|'none' Border preset; falls back to `vim.o.winborder` when nil
 
 --- @class FffPreviewConfig
 --- @field enabled boolean
@@ -225,6 +226,10 @@ local function init()
       prompt_position = 'bottom', -- or 'top'
       preview_position = 'right', -- or 'left', 'right', 'top', 'bottom'
       preview_size = 0.5,
+      -- Border style for the picker windows: 'single', 'double', 'rounded',
+      -- 'solid', 'shadow' or 'none'. Leave unset (nil) to follow the global
+      -- `vim.o.winborder` setting.
+      border = nil,
       flex = { -- set to nil to disable flex layout
         size = 130, -- column threshold: if screen width >= size, use preview_position; otherwise use wrap
         wrap = 'top', -- position to use when screen is narrower than size

--- a/lua/fff/layout.lua
+++ b/lua/fff/layout.lua
@@ -21,10 +21,15 @@ local T_JUNCTION_PRESETS = {
   none = { '', '', '', '', '' },
 }
 
-local function get_border_chars()
-  local winborder = vim.o.winborder or 'single'
+-- Resolve which border preset to draw. `config.layout.border` overrides the
+-- global `winborder`; when unset we fall back to `vim.o.winborder` so fff keeps
+-- respecting the user's global preference.
+local function get_border_chars(config)
+  local border = config and config.layout and config.layout.border
+  if border == nil or border == '' then border = vim.o.winborder end
+  if border == nil or border == '' then border = 'single' end
 
-  if BORDER_PRESETS[winborder] then return BORDER_PRESETS[winborder], T_JUNCTION_PRESETS[winborder] end
+  if BORDER_PRESETS[border] then return BORDER_PRESETS[border], T_JUNCTION_PRESETS[border] end
   return BORDER_PRESETS.single, T_JUNCTION_PRESETS.single
 end
 
@@ -244,7 +249,7 @@ end
 --- Build the per-window configs (for `nvim_open_win`) from a finished layout.
 --- Handles all the corner/T-junction resolution so adjacent floats line up.
 local function build_window_configs(layout, config, prompt_position, preview_position)
-  local border_chars, t_junctions = get_border_chars()
+  local border_chars, t_junctions = get_border_chars(config)
   local has_preview = layout.preview ~= nil
   local title = ' ' .. (config.title or 'FFFiles') .. ' '
 


### PR DESCRIPTION
Adds an optional `layout.border` config option that lets fff set its own window border style independently of the global `vim.o.winborder`. When unset, fff keeps following `vim.o.winborder` (then falls back to `single`).

Accepts the existing border presets: single, double, rounded, solid, shadow, none.

closes #638