### PR TITLE
feat(zig): be less strict on the zig executable

### DIFF
--- a/crates/fff-core/build.rs
+++ b/crates/fff-core/build.rs
@@ -41,6 +41,5 @@ fn zig_available() -> bool {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .is_ok()
 }


### PR DESCRIPTION
Some zig version managers (notably the popular https://github.com/marler8997/anyzig ) hog the `zig` executable.
Anyzig in particular does not return success on an invocation without a build.zig.zon with the field minimum_zig_version in the cwd.

This change makes the zig executable check less strict on the assumptions of the `zig` executable and simply checks if it is present and callable.
This change makes `cargo build` work when zig is installed via `anyzig`.

Works on my machine™️