### PR TITLE
fix(nvim): use configurable grep_match hl in preview (#646)

### DIFF
--- a/lua/fff/location_utils.lua
+++ b/lua/fff/location_utils.lua
@@ -154,6 +154,7 @@ function M.highlight_grep_matches(bufnr, location, namespace)
 
   local line_count = vim.api.nvim_buf_line_count(bufnr)
   local extmarks = {}
+  local grep_hl = require('fff.conf').get().hl.grep_match or 'IncSearch'
 
   -- Pin CursorLine + CursorLineNr to the target match line via extmark, so
   -- the highlight stays anchored when the user pages the preview viewport
@@ -181,7 +182,7 @@ function M.highlight_grep_matches(bufnr, location, namespace)
       local end_byte = range[2] -- 0-based exclusive end
       local ok, mark_id = pcall(vim.api.nvim_buf_set_extmark, bufnr, namespace, target_line - 1, start_byte, {
         end_col = end_byte,
-        hl_group = 'IncSearch',
+        hl_group = grep_hl,
         priority = 1000,
       })
       if ok then table.insert(extmarks, { id = mark_id, line = target_line - 1 }) end
@@ -225,7 +226,7 @@ function M.highlight_grep_matches(bufnr, location, namespace)
       -- s and e are 1-based byte positions; extmarks need 0-based
       local ok, mark_id = pcall(vim.api.nvim_buf_set_extmark, bufnr, namespace, i - 1, s - 1, {
         end_col = e,
-        hl_group = 'IncSearch',
+        hl_group = grep_hl,
         priority = 1000,
       })
       if ok then table.insert(extmarks, { id = mark_id, line = i - 1 }) end


### PR DESCRIPTION
Closes #646

## Root cause
`lua/fff/location_utils.lua` hardcoded `IncSearch` for grep match highlights in the preview window (lines 184, 228), while the results list uses `config.hl.grep_match` (`lua/fff/picker_ui/grep_renderer.lua:232`). Overriding `hl.grep_match` in the user config styled the results list but not the preview, and overriding the global `IncSearch` group did not propagate either (likely due to the preview's `winhighlight` remapping `Normal` and treesitter groups painting over the extmark background in some colorschemes).

## Fix
Read `config.hl.grep_match` in `highlight_grep_matches` and use it for both the fuzzy and plain/regex code paths, falling back to `IncSearch` when unset. Preview and results now share the same configurable highlight group.

## Steps to reproduce
Setup:
```lua
-- repro.lua
vim.pack.add({ "https://github.com/dmtrKovalenko/fff.nvim" })
vim.api.nvim_create_autocmd("PackChanged", {
  callback = function(ev)
    local name, kind = ev.data.spec.name, ev.data.kind
    if name == "fff.nvim" and (kind == "install" or kind == "update") then
      if not ev.data.active then vim.cmd.packadd("fff.nvim") end
      require("fff.download").download_or_build_binary()
    end
  end,
})
vim.g.fff = { lazy_sync = true }
-- Try to restyle grep matches:
vim.api.nvim_set_hl(0, "IncSearch", { bg = "#ff00ff", fg = "#000000" })
```
Trigger:
```
nvim -u repro.lua
:lua require("fff").live_grep()
```
Type any query.

Expected: matched substrings in the preview have the magenta background.
Actual (pre-fix): matches in the results list are magenta, matches in the preview window keep the theme's washed-out `IncSearch` (or no background at all under `gruvbox-material`, per screenshots in the issue).

## How verified
Manual repro on macOS with the config above; after the fix the preview highlights honor the overridden `IncSearch`, and setting `hl.grep_match = 'Visual'` in the fff config now restyles both list and preview consistently.

Automated triage via Gustav. Honk-Honk 🪿