### PR TITLE
fix(pi-fff): feature-detect ctx.ui.addAutocompleteProvider (#651)

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -403,11 +403,15 @@ export default function fffExtension(pi: ExtensionAPI) {
 
   function registerAutocompleteProvider(ctx: {
     ui: {
-      addAutocompleteProvider: (
+      addAutocompleteProvider?: (
         factory: (current: AutocompleteProvider) => AutocompleteProvider,
       ) => void;
     };
   }) {
+    // pi forks (e.g. omp) may not expose addAutocompleteProvider; skip UI wiring
+    // and let tools continue to work instead of failing session_start.
+    if (typeof ctx.ui.addAutocompleteProvider !== "function") return;
+
     ctx.ui.addAutocompleteProvider((current) => {
       const mentionProvider = createFffMentionProvider(getMentionItems);
 

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -161,6 +161,24 @@ describe("pi-fff autocomplete registration", () => {
     ]);
   });
 
+  test("session_start survives hosts without addAutocompleteProvider", async () => {
+    const setup = createPi();
+    const ctx = {
+      cwd: "/tmp/workspace",
+      ui: {
+        notify: mock(() => undefined),
+        setEditorComponent: mock(() => undefined),
+      },
+    };
+    fffExtension(setup.pi as any);
+
+    const sessionStart = setup.events.get("session_start");
+    await sessionStart?.({ reason: "startup" }, ctx);
+
+    expect(ctx.ui.notify).not.toHaveBeenCalled();
+    expect(createCalls).toHaveLength(1);
+  });
+
   test("delegates non-@ completions to the current provider", async () => {
     const { ctx } = await start();
     const factory = ctx.ui.addAutocompleteProvider.mock.calls[0][0];


### PR DESCRIPTION
Closes #651

## Root cause

`packages/pi-fff/src/index.ts:411` calls `ctx.ui.addAutocompleteProvider` unconditionally inside `session_start`. The type at `:406` also declares it as required. On pi forks that do not expose this method (omp, reported in #651), the call throws and the `catch` in `session_start` (`:496-501`) surfaces `FFF init failed: ctx.ui.addAutocompleteProvider is not a function` — and, more importantly, tool registration for the session never completes.

## Fix

Mark `addAutocompleteProvider` as optional in the accepted `ctx` shape and feature-detect it before calling. When absent, skip the UI wiring and return — tools (find/grep/multi_grep) still register normally.

## Steps to reproduce

Pre-fix, on `origin/main`:

```sh
git checkout origin/main
cd packages/pi-fff
bun install
```

Add a repro test that mimics an omp-style host lacking `addAutocompleteProvider`:

```ts
// packages/pi-fff/test/repro.test.ts
import { test, expect, mock } from "bun:test";
import fffExtension from "../src/index";

test("host without addAutocompleteProvider", async () => {
  const events = new Map<string, any>();
  const pi = {
    getFlag: mock(() => undefined),
    on: mock((e: string, h: any) => { events.set(e, h); }),
    registerCommand: mock(() => undefined),
    registerFlag: mock(() => undefined),
    registerTool: mock(() => undefined),
    appendEntry: mock(() => undefined),
  };
  const ctx = {
    cwd: "/tmp/workspace",
    ui: { notify: mock(() => undefined), setEditorComponent: mock(() => undefined) },
    // NOTE: no addAutocompleteProvider — matches omp fork surface
  };
  fffExtension(pi as any);
  await events.get("session_start")({ reason: "startup" }, ctx);
  expect(ctx.ui.notify).not.toHaveBeenCalled();
});
```

Run:

```sh
bun test test/repro.test.ts
```

Expected: pass.
Actual on `origin/main`: fails — `ctx.ui.notify` is called with `FFF init failed: ctx.ui.addAutocompleteProvider is not a function`, matching the traceback in the issue.

## How verified

```sh
cd packages/pi-fff
bun test test/extension.test.ts
```

Output: `8 pass, 0 fail` — includes the new `session_start survives hosts without addAutocompleteProvider` regression test plus the existing 7 tests unchanged.

Automated triage via Gustav. Honk-Honk 🪿