### PR TITLE
fix(core): restrict AVX2 normalize to x86_64 (fix i686 build)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -101,6 +101,32 @@ jobs:
           path: crates/fff-core/tests/fuzz_git_watcher_stress.proptest-regressions
           if-no-files-found: ignore
 
+  build-i686:
+    name: Build i686-unknown-linux-gnu
+    runs-on: ubuntu-latest
+    # Verifies that fff-search compiles on 32-bit x86, where std::arch::x86_64
+    # is unavailable. SIMD paths are disabled on this target; only the scalar
+    # fallback should build. See issue #656.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install cross toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib g++-multilib
+
+      - name: Install Rust (i686 target)
+        uses: actions-rust-lang/setup-rust-toolchain@v1.15.4
+        with:
+          target: i686-unknown-linux-gnu
+          cache: true
+          cache-on-failure: true
+          cache-key: "v1-rust-i686"
+
+      - name: Build fff-search for i686
+        run: cargo build -p fff-search --target i686-unknown-linux-gnu
+
   fmt:
     name: cargo fmt
     runs-on: ubuntu-latest

--- a/crates/fff-core/src/bigram_filter.rs
+++ b/crates/fff-core/src/bigram_filter.rs
@@ -593,7 +593,7 @@ fn normalize_byte_scalar(b: u8) -> u8 {
 #[inline(always)]
 fn normalize_bytes(src: &[u8], dst: &mut [u8]) {
     debug_assert!(dst.len() >= src.len());
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    #[cfg(target_arch = "x86_64")]
     {
         if std::is_x86_feature_detected!("avx2") {
             unsafe { normalize_bytes_avx2(src, dst) };
@@ -620,7 +620,7 @@ fn normalize_bytes_scalar(src: &[u8], dst: &mut [u8]) {
 
 /// AVX2 normalize: 32 bytes/iter. AVX2 only has signed cmp, so unsigned
 /// range checks use `min(max(v, lo), hi) == v`.
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn normalize_bytes_avx2(src: &[u8], dst: &mut [u8]) {
     use std::arch::x86_64::*;

--- a/crates/fff-core/src/case_insensitive_memmem.rs
+++ b/crates/fff-core/src/case_insensitive_memmem.rs
@@ -496,6 +496,10 @@ pub fn search_packed_pair(haystack: &[u8], needle_lower: &[u8]) -> bool {
         return false;
     }
 
+    #[cfg_attr(
+        not(any(target_arch = "x86_64", target_arch = "aarch64")),
+        allow(unused_variables)
+    )]
     let (i1, i2) = select_rare_pair(needle_lower);
 
     #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
Closes #656

## Root cause
`normalize_bytes` in `crates/fff-core/src/bigram_filter.rs` gated the AVX2 dispatch and the `normalize_bytes_avx2` fn on `#[cfg(any(target_arch = \"x86_64\", target_arch = \"x86\"))]`, but the body unconditionally does `use std::arch::x86_64::*;`. On 32-bit x86 (`i686-unknown-linux-gnu`) `std::arch::x86_64` does not exist, so `fff-search` failed to compile:

```
error[E0432]: unresolved import `std::arch::x86_64`
   --> fff-search-0.9.6/src/bigram_filter.rs:626:20
    |
626 |     use std::arch::x86_64::*;
    |                    ^^^^^^ could not find `x86_64` in `arch`
```

Regressed in #566. Reported by @Juhan280 hitting this while packaging nushell for termux i686 android devices.

## Fix
Restrict the AVX2 dispatch and the `normalize_bytes_avx2` implementation to `#[cfg(target_arch = \"x86_64\")]`. On 32-bit x86 we fall back to `normalize_bytes_scalar`, which LLVM auto-vectorises with the baseline SIMD anyway. Per maintainer + @fdncred: dropping SIMD on 32-bit x86 is acceptable — compiling at all is more important.

Also add a `Build i686-unknown-linux-gnu` CI job in `.github/workflows/rust.yml` so this regresses loudly next time. The job installs `gcc-multilib`, adds the `i686-unknown-linux-gnu` target, and runs `cargo build -p fff-search --target i686-unknown-linux-gnu`.

## Steps to reproduce
On pre-fix `main` (commit 8c76a1b):

```sh
rustup target add i686-unknown-linux-gnu
sudo apt-get install -y gcc-multilib   # linux host
cargo build -p fff-search --target i686-unknown-linux-gnu
```

Expected: build succeeds. Actual on pre-fix `main`: `error[E0432]: unresolved import 'std::arch::x86_64'` at `crates/fff-core/src/bigram_filter.rs:626`.

## How verified
- `cargo check -p fff-search --no-default-features --features ripgrep` on x86_64 macOS: clean.
- `cargo clippy -p fff-search --no-default-features --features ripgrep -- -D warnings`: clean.
- New CI job exercises the i686 build path on every PR; cross-compile toolchain not available locally on macOS host, so verification of the 32-bit target itself is deferred to CI.

Automated triage via Gustav. Honk-Honk 🪿