### PR TITLE
fix(core): emit compile_error for --no-default-features (#659)

### DIFF
--- a/crates/fff-core/src/constraints.rs
+++ b/crates/fff-core/src/constraints.rs
@@ -169,7 +169,7 @@ pub(crate) fn apply_constraints<'a, T: Constrainable + Sync>(
 
 #[cfg(feature = "zlob")]
 type GlobPattern = zlob::ZlobPattern;
-#[cfg(not(feature = "zlob"))]
+#[cfg(all(not(feature = "zlob"), feature = "ripgrep"))]
 type GlobPattern = globset::GlobMatcher;
 
 /// How `Constraint::Glob` is evaluated for each item.
@@ -440,7 +440,7 @@ fn compiled_matches(p: &GlobPattern, path: &str) -> bool {
 }
 
 #[inline]
-#[cfg(not(feature = "zlob"))]
+#[cfg(all(not(feature = "zlob"), feature = "ripgrep"))]
 fn compiled_matches(p: &GlobPattern, path: &str) -> bool {
     p.is_match(path)
 }
@@ -553,7 +553,7 @@ fn compile_one(pattern: &str) -> Option<GlobPattern> {
     zlob::ZlobPattern::compile(pattern, zlob::ZlobFlags::RECOMMENDED).ok()
 }
 
-#[cfg(not(feature = "zlob"))]
+#[cfg(all(not(feature = "zlob"), feature = "ripgrep"))]
 fn compile_one(pattern: &str) -> Option<GlobPattern> {
     globset::Glob::new(pattern)
         .ok()
@@ -577,7 +577,7 @@ fn match_glob_pattern(pattern: &str, paths: &[&str]) -> Vec<bool> {
     mask
 }
 
-#[cfg(not(feature = "zlob"))]
+#[cfg(all(not(feature = "zlob"), feature = "ripgrep"))]
 fn match_glob_pattern(pattern: &str, paths: &[&str]) -> Vec<bool> {
     let mut mask = vec![false; paths.len()];
     let Ok(glob) = globset::Glob::new(pattern) else {

--- a/crates/fff-core/src/ignore.rs
+++ b/crates/fff-core/src/ignore.rs
@@ -39,7 +39,7 @@ pub(crate) const IGNORED_DIRS: &[&str] = &[
     "AppData/Roaming",
 ];
 
-#[cfg(not(feature = "zlob"))]
+#[cfg(all(not(feature = "zlob"), feature = "ripgrep"))]
 pub(crate) fn non_git_repo_overrides(base_path: &Path) -> Option<ignore::overrides::Override> {
     use ignore::overrides::OverrideBuilder;
 

--- a/crates/fff-core/src/lib.rs
+++ b/crates/fff-core/src/lib.rs
@@ -94,6 +94,12 @@
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 
+#[cfg(not(any(feature = "ripgrep", feature = "zlob")))]
+compile_error!(
+    "fff-search requires either the `ripgrep` (default) or `zlob` feature. \
+     Enable one, e.g. `--features ripgrep` or `--features zlob`."
+);
+
 mod background_watcher;
 mod git_status_worker;
 pub(crate) mod parallelism;

--- a/crates/fff-core/src/walk/mod.rs
+++ b/crates/fff-core/src/walk/mod.rs
@@ -13,9 +13,9 @@ mod zlob;
 #[cfg(feature = "zlob")]
 pub(crate) use zlob::walk_collect_files;
 
-#[cfg(not(feature = "zlob"))]
+#[cfg(all(not(feature = "zlob"), feature = "ripgrep"))]
 mod ripgrep;
-#[cfg(not(feature = "zlob"))]
+#[cfg(all(not(feature = "zlob"), feature = "ripgrep"))]
 pub(crate) use ripgrep::walk_collect_files;
 
 pub(crate) struct WalkOutput {


### PR DESCRIPTION
Closes #659

## Root cause

`fff-search` has two mutually exclusive backend features (`ripgrep` default, `zlob`), but internal cfg gates for ripgrep-only code used `cfg(not(feature = "zlob"))` instead of `cfg(feature = "ripgrep")` — see `crates/fff-core/src/ignore.rs:42`, `crates/fff-core/src/walk/mod.rs:16`, `crates/fff-core/src/constraints.rs:172` / `443` / `556` / `580`. With `--no-default-features` neither feature is set, so the ripgrep branches were compiled but the `ignore` / `globset` deps (gated on `dep:ignore` / `dep:globset` behind the `ripgrep` feature) were absent, yielding 15 cascading "unresolved module or unlinked crate" errors.

## Fix

- Tighten the affected gates to `all(not(feature = "zlob"), feature = "ripgrep")` so the ripgrep code is skipped when the ripgrep feature is off.
- Add a top-level `compile_error!` in `crates/fff-core/src/lib.rs` when neither backend feature is enabled, so the failure is a single actionable message instead of a cascade.

## Steps to reproduce

Setup:

```sh
git clone https://github.com/dmtrKovalenko/fff.git
cd fff
```

Trigger (on pre-fix `main`):

```sh
cargo check -p fff-search --no-default-features
```

Expected: build succeeds, or `cargo` emits a clear diagnostic identifying the required feature.

Actual (pre-fix): 15 errors, first ones:

```
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `ignore`
  --> crates/fff-core/src/ignore.rs:44:9
error[E0432]: unresolved import `ignore`
 --> crates/fff-core/src/walk/ripgrep.rs:5:5
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `globset`
   --> crates/fff-core/src/constraints.rs:558:5
...
error: could not compile `fff-search` (lib) due to 15 previous errors
```

## How verified

```sh
cargo check -p fff-search --no-default-features                    # single compile_error diagnostic
cargo check -p fff-search --no-default-features --features ripgrep # ok
cargo check -p fff-search                                          # ok (default = ripgrep)
cargo check -p fff-search --no-default-features --features zlob    # ok
cargo test  -p fff-search --lib --no-default-features --features ripgrep # 98 passed; 0 failed
```

Top of `--no-default-features` output after the fix:

```
error: fff-search requires either the `ripgrep` (default) or `zlob` feature. Enable one, e.g. `--features ripgrep` or `--features zlob`.
```

Automated triage via Gustav. Honk-Honk 🪿