### PR TITLE
chore(deps): bump crossbeam-epoch, anyhow, memmap2 for RustSec advisories (#670)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayref"
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1440,9 +1440,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Closes #670

## Root cause
`cargo audit` on `origin/main` (b4590ca) reports 3 vulnerabilities and 6 warnings against transitive/direct deps in `Cargo.lock`:

- `crossbeam-epoch 0.9.18` — RUSTSEC-2026-0204 (vulnerability, invalid pointer deref in `fmt::Pointer` for `Atomic`/`Shared`)
- `anyhow 1.0.102` — RUSTSEC-2026-0190 (unsound, `Error::downcast_mut()`)
- `memmap2 0.9.10` — RUSTSEC-2026-0186 (unsound, unchecked pointer offset)

All three have semver-compatible fixed releases, so a lockfile bump is sufficient — no manifest edits needed.

## Fix
Lockfile-only updates via `cargo update -p`:
- `crossbeam-epoch` 0.9.18 → 0.9.20
- `anyhow` 1.0.102 → 1.0.103
- `memmap2` 0.9.10 → 0.9.11

## Not fixed here (out of scope for a triage-bot PR)
- `pyo3 0.24.2` (RUSTSEC-2026-0176, RUSTSEC-2026-0177) requires bump to `>=0.29.0`. That is 5 major-version jumps with API-breaking changes across `crates/fff-python/src/{lib,finder,types,conversions}.rs`. Grep confirms the vulnerable APIs (`PyList::nth`/`PyTuple::nth`, `PyCFunction::new_closure`) are **not** used in this crate, so exposure is nil. Leaving for @dmtrKovalenko to schedule as a dedicated bump.
- `git2 0.20.4` (RUSTSEC-2026-0183, RUSTSEC-2026-0184) — no fixed release in the 0.20.x line; `Remote::list()` and `BlameHunk::signature()` are not called anywhere in the workspace (grep clean).
- `rand 0.8.5` (RUSTSEC-2026-0097) — dev-dep / transitive via `phf_generator`, not in the runtime path.
- `bincode 1.3.3` (RUSTSEC-2025-0141, unmaintained) — transitive via `heed-types`; upstream must move first.

## Steps to reproduce
```sh
git fetch origin main
git checkout b4590ca
cargo install cargo-audit --locked  # if not installed
cargo audit
```
Expected on pre-fix `main`:
```
error: 3 vulnerabilities found!
warning: 6 allowed warnings found
```
with `crossbeam-epoch 0.9.18`, `pyo3 0.24.2` x2 listed as vulnerabilities.

## How verified
```sh
cargo update -p crossbeam-epoch -p anyhow -p memmap2
cargo check --workspace   # clean
cargo test -p fff-search --lib   # 103 passed; 0 failed
cargo audit
```
Post-fix `cargo audit`:
```
error: 2 vulnerabilities found!   # both pyo3, see "Not fixed here"
warning: 4 allowed warnings found
```
RUSTSEC-2026-0204, -0190, -0186 no longer reported.

Automated triage via Gustav. Honk-Honk 🪿