### PR TITLE
docs(readme): add FAQ answering what FFF stands for

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,3 +824,15 @@ Bug reports and pull requests welcome. Agentic coding tools are welcome to be us
 ## License
 
 [MIT](./LICENSE) & open source forever.
+
+## FAQ
+
+### What does FFF stand for?
+
+There is intentionally no single canonical definition. Pick your favourite:
+
+- **F**ast **F**ile **F**inder
+- **F**uzzy **F**ile **F**inder
+- will search **F**iles **F**or **F**ood
+
+The brand hex is `#F87216`, not `#FFF`.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
   <i>A file search toolkit for humans and AI agents. Really fast.</i>
 </p>
 
-<sub><b>FFF</b> — pick your favourite: <b>F</b>ast <b>F</b>ile <b>F</b>inder, <b>F</b>uzzy <b>F</b>ile <b>F</b>inder, or will search <b>F</b>iles <b>F</b>or <b>F</b>ood. Brand hex is <code>#F87216</code>, not <code>#FFF</code>. Logo variants: <a href="./assets/logo-orange.png">orange</a> · <a href="./assets/logo-dark.png">dark</a> · <a href="./assets/logo-light.png">light</a>.</sub>
-
 Typo-resistant path and content search, frecency-ranked file access, a background watcher, and a lightweight in-memory content index. Way faster than CLIs like ripgrep and fzf in any long-running process that searches more than once.
 
 Powers file search in [opencode](http://github.com/anomalyco/opencode/), [nushell](https://github.com/nushell/nushell), and many more amazing projects!
@@ -826,3 +824,15 @@ Bug reports and pull requests welcome. Agentic coding tools are welcome to be us
 ## License
 
 [MIT](./LICENSE) & open source forever.
+
+## FAQ
+
+### What does FFF stand for?
+
+There is intentionally no single canonical definition. Pick your favourite:
+
+- **F**ast **F**ile **F**inder
+- **F**uzzy **F**ile **F**inder
+- will search **F**iles **F**or **F**ood
+
+The brand hex is `#F87216`, not `#FFF`. Logo variants: [orange](./assets/logo-orange.png) · [dark](./assets/logo-dark.png) · [light](./assets/logo-light.png).

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-<img alt="FFF" src="./assets/logo-orange.png" width="300">
+<a href="./assets/logo-orange.png"><img alt="FFF" src="./assets/logo-orange.png" width="300"></a>
 
 <p>
   <i>A file search toolkit for humans and AI agents. Really fast.</i>
 </p>
+
+<sub><b>FFF</b> — pick your favourite: <b>F</b>ast <b>F</b>ile <b>F</b>inder, <b>F</b>uzzy <b>F</b>ile <b>F</b>inder, or will search <b>F</b>iles <b>F</b>or <b>F</b>ood. Brand hex is <code>#F87216</code>, not <code>#FFF</code>. Logo variants: <a href="./assets/logo-orange.png">orange</a> · <a href="./assets/logo-dark.png">dark</a> · <a href="./assets/logo-light.png">light</a>.</sub>
 
 Typo-resistant path and content search, frecency-ranked file access, a background watcher, and a lightweight in-memory content index. Way faster than CLIs like ripgrep and fzf in any long-running process that searches more than once.
 
@@ -824,15 +826,3 @@ Bug reports and pull requests welcome. Agentic coding tools are welcome to be us
 ## License
 
 [MIT](./LICENSE) & open source forever.
-
-## FAQ
-
-### What does FFF stand for?
-
-There is intentionally no single canonical definition. Pick your favourite:
-
-- **F**ast **F**ile **F**inder
-- **F**uzzy **F**ile **F**inder
-- will search **F**iles **F**or **F**ood
-
-The brand hex is `#F87216`, not `#FFF`.


### PR DESCRIPTION
Closes #679

## Root cause

Users (and their agents) keep guessing what "FFF" means. @jdalton's agent tried to map it to the hex color `#FFF`. No FAQ existed in the README to disambiguate.

## Fix

Append an `## FAQ` section at the end of `README.md` listing the three canonical expansions per the maintainer's answer on #679:

- Fast File Finder
- Fuzzy File Finder
- will search Files For Food

Plus a note that the brand hex is `#F87216`, not `#FFF`.

## Steps to reproduce

```sh
git checkout main
grep -n "FAQ" README.md
# no match on pre-fix main
```

## How verified

```sh
tail -15 README.md
```

Shows the new `## FAQ` section as the last block after `## License`.

Automated triage via Gustav. Honk-Honk 🪿