### PR TITLE
feat(c): add stable FffResult accessors

### DIFF
--- a/crates/fff-c/include/fff.h
+++ b/crates/fff-c/include/fff.h
@@ -961,6 +961,40 @@ const struct FffScore *fff_mixed_search_result_get_score(const struct FffMixedSe
                                                          uint32_t index);
 
 /**
+ * Returns whether the operation completed successfully. Returns `false` if `result` is null.
+ *
+ * ## Safety
+ * `result` must be a valid `FffResult` pointer or null.
+ */
+bool fff_result_get_success(const struct FffResult *result);
+
+/**
+ * Returns the operation error message, or null when there is no error or `result` is null.
+ *
+ * Do not free the returned pointer. It remains valid until `fff_free_result` is called.
+ *
+ * ## Safety
+ * `result` must be a valid `FffResult` pointer or null.
+ */
+const char *fff_result_get_error(const struct FffResult *result);
+
+/**
+ * Returns the result payload handle, or null if `result` is null.
+ *
+ * ## Safety
+ * `result` must be a valid `FffResult` pointer or null.
+ */
+void *fff_result_get_handle(const struct FffResult *result);
+
+/**
+ * Returns the result integer payload. Returns `0` if `result` is null.
+ *
+ * ## Safety
+ * `result` must be a valid `FffResult` pointer or null.
+ */
+int64_t fff_result_get_int_value(const struct FffResult *result);
+
+/**
  * Returns the relative path of a file item (e.g. `"src/main.rs"`).
  *
  * Returns null if `item` is null. The returned pointer is valid for the

--- a/crates/fff-c/src/accessors.rs
+++ b/crates/fff-c/src/accessors.rs
@@ -29,7 +29,61 @@
 use std::ffi::c_char;
 use std::ptr;
 
-use crate::ffi_types::{FffFileItem, FffGrepMatch, FffGrepResult, FffMatchRange, FffSearchResult};
+use crate::ffi_types::{
+    FffFileItem, FffGrepMatch, FffGrepResult, FffMatchRange, FffResult, FffSearchResult,
+};
+
+// ── FffResult ────────────────────────────────────────────────────────────────
+
+/// Returns whether the operation completed successfully. Returns `false` if `result` is null.
+///
+/// ## Safety
+/// `result` must be a valid `FffResult` pointer or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fff_result_get_success(result: *const FffResult) -> bool {
+    if result.is_null() {
+        return false;
+    }
+    unsafe { (*result).success }
+}
+
+/// Returns the operation error message, or null when there is no error or `result` is null.
+///
+/// Do not free the returned pointer. It remains valid until `fff_free_result` is called.
+///
+/// ## Safety
+/// `result` must be a valid `FffResult` pointer or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fff_result_get_error(result: *const FffResult) -> *const c_char {
+    if result.is_null() {
+        return ptr::null();
+    }
+    unsafe { (*result).error }
+}
+
+/// Returns the result payload handle, or null if `result` is null.
+///
+/// ## Safety
+/// `result` must be a valid `FffResult` pointer or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fff_result_get_handle(result: *const FffResult) -> *mut std::ffi::c_void {
+    if result.is_null() {
+        return ptr::null_mut();
+    }
+    unsafe { (*result).handle }
+}
+
+/// Returns the result integer payload. Returns `0` if `result` is null.
+///
+/// ## Safety
+/// `result` must be a valid `FffResult` pointer or null.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn fff_result_get_int_value(result: *const FffResult) -> i64 {
+    if result.is_null() {
+        return 0;
+    }
+    unsafe { (*result).int_value }
+}
 
 // ── FffFileItem ──────────────────────────────────────────────────────────────
 
@@ -801,7 +855,40 @@ mod tests {
         }
     }
 
+    #[test]
+    fn null_result_returns_zero_or_null() {
+        let null: *const FffResult = ptr::null();
+        unsafe {
+            assert!(!fff_result_get_success(null));
+            assert!(fff_result_get_error(null).is_null());
+            assert!(fff_result_get_handle(null).is_null());
+            assert_eq!(fff_result_get_int_value(null), 0);
+        }
+    }
+
     // ── data correctness tests ────────────────────────────────────────────────
+
+    #[test]
+    fn result_getters_return_correct_values() {
+        let error = CString::new("failed").unwrap();
+        let handle = 0x1234usize as *mut std::ffi::c_void;
+        let result = FffResult {
+            success: false,
+            error: error.as_ptr() as *mut std::ffi::c_char,
+            handle,
+            int_value: -7,
+        };
+        let p = &result as *const FffResult;
+        unsafe {
+            assert!(!fff_result_get_success(p));
+            assert_eq!(
+                std::ffi::CStr::from_ptr(fff_result_get_error(p)),
+                error.as_c_str()
+            );
+            assert_eq!(fff_result_get_handle(p), handle);
+            assert_eq!(fff_result_get_int_value(p), -7);
+        }
+    }
 
     #[test]
     fn file_item_getters_return_correct_values() {


### PR DESCRIPTION
## Summary
- add stable C accessors for public `FffResult` payload fields
- regenerate the public C header
- cover success, error, pointer, integer, and NULL-result behavior

## Motivation
Consumers should not need to depend on the in-memory layout of `FffResult`. Named accessors make the ABI consumption explicit and let clients such as `fff.el` avoid raw offsets.

## Validation
- `cargo fmt --check -p fff-c`
- `cargo test -p fff-c --lib`
- verified exported symbols with `nm -D`