### PR TITLE
fix(pi-fff): handle Windows cross-volume external paths

### DIFF
--- a/packages/pi-fff/src/aux-finders.ts
+++ b/packages/pi-fff/src/aux-finders.ts
@@ -128,6 +128,14 @@ export function resolveAuxRoot(
   return null;
 }
 
+export function isOutsideWorkspaceRelativePath(relativePath: string): boolean {
+  return (
+    path.isAbsolute(relativePath) ||
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`)
+  );
+}
+
 // Decide whether a `path` parameter should route to the workspace finder or
 // to an aux finder. Accepts absolute paths, `~`-prefixed paths, and relative
 // paths escaping the workspace (`../other-project`); everything is resolved
@@ -147,7 +155,7 @@ export function routePathConstraint(
     candidate = path.resolve(cwd, candidate);
   }
   const rel = path.relative(cwd, candidate);
-  if (rel !== ".." && !rel.startsWith(`..${path.sep}`)) return null;
+  if (!isOutsideWorkspaceRelativePath(rel)) return null;
   return resolveAuxRoot(candidate);
 }
 

--- a/packages/pi-fff/test/aux-finders.test.ts
+++ b/packages/pi-fff/test/aux-finders.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  isOutsideWorkspaceRelativePath,
   resolveAuxRoot,
   rootCovers,
   routePathConstraint,
@@ -27,6 +28,14 @@ describe("routePathConstraint", () => {
     const route = routePathConstraint("/tmp", cwd);
     expect(route).toEqual({ root: "/tmp", suffix: "" });
   });
+
+  if (process.platform === "win32") {
+    test("treats a cross-volume relative result as outside the workspace", () => {
+      const rel = path.win32.relative("D:\\workspace", "C:\\target");
+      expect(rel).toBe("C:\\target");
+      expect(isOutsideWorkspaceRelativePath(rel)).toBe(true);
+    });
+  }
 
   test("splits glob suffix from existing dir prefix", () => {
     const route = routePathConstraint("/tmp/**/*.ts", cwd);


### PR DESCRIPTION
## Problem

`routePathConstraint()` decides whether a `path` parameter points
outside the workspace and should be served by an aux (secondary)
file index. The existing outside-workspace check only handles
Unix-style `../` and Windows `..\` escapes:

```js
if (rel !== ".." && !rel.startsWith(`..${path.sep}`)) return null;
```

On Windows, `path.relative('D:\workspace', 'C:\target')` returns
`C:\target` — an absolute path, not a `..`-prefixed one. This
slips through the check, the path is misclassified as
workspace-local, and downstream code rejects it with:

```
Path constraint must be relative to the workspace
```

## Fix

1. Introduce `isOutsideWorkspaceRelativePath()` — a named, testable
   helper that checks:
   - `path.isAbsolute(rel)` — catches Windows cross-volume results
   - `rel === ".."` — parent directory escape
   - `rel.startsWith(`..${path.sep}`)` — nested escape (`../foo` or
     `..\foo`)

2. Use it in `routePathConstraint()` in place of the inline
   condition.

The change is a single semantic addition (`path.isAbsolute()`) that
completes the existing "is this path outside the workspace?" test
for a case that was simply overlooked.

## Testing

- `npm run typecheck --workspace=@ff-labs/pi-fff`: passes
- `bun test test/aux-finders.test.ts` with the new Windows test: 1
  pass, 0 fail (20 existing tests unchanged)
- Gated on `process.platform === "win32"` — skipped on Linux/macOS CI

## Scope

`packages/pi-fff/` only. No changes to Rust crates, C header, MCP
server, Neovim plugin, or other packages.
