### PR TITLE
fix(mcp): use absolute path for Codex setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,31 @@ brew upgrade fff-mcp   # after new stable releases
 
 Formula lives in [`Formula/fff-mcp.rb`](./Formula/fff-mcp.rb) in this repo and is **auto-bumped on every stable release** (see `bump-homebrew-formula` in [`.github/workflows/release.yaml`](./.github/workflows/release.yaml)). Installs the prebuilt `fff-mcp` binary from [GitHub releases](https://github.com/dmtrKovalenko/fff.nvim/releases).
 
+### Codex setup
+
+Register the installed binary using its absolute path, since Codex desktop sessions may not inherit your interactive shell's `PATH`.
+
+Homebrew:
+
+```bash
+codex mcp add fff -- "$(brew --prefix)/bin/fff-mcp"
+```
+
+One-line installer:
+
+```bash
+codex mcp add fff -- "$HOME/.local/bin/fff-mcp"
+```
+
+This creates an entry in `~/.codex/config.toml` similar to:
+
+```toml
+[mcp_servers.fff]
+command = "/opt/homebrew/bin/fff-mcp"
+```
+
+Use the actual installed path for your system, then restart Codex or start a new task so it loads the server.
+
 Once the server is connected, ask the agent to "use fff" and it picks up the `ffgrep`, `fffind`, and `fff-multi-grep` tools.
 
 ### Recommended agent prompt

--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -209,7 +209,7 @@ function Show-SetupInstructions {
     if (Get-Command codex -ErrorAction SilentlyContinue) {
         $foundAny = $true
         Write-Success "[Codex] detected"
-        Write-Host "codex mcp add fff -- fff-mcp"
+        Write-Host "codex mcp add fff -- `"$BinaryPath`""
         Write-Host ""
     }
 

--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -262,7 +262,7 @@ print_setup_instructions() {
         found_any=true
         success "[Codex] detected"
         echo ""
-        echo "codex mcp add fff -- fff-mcp"
+        echo "codex mcp add fff -- \"${binary_path}\""
         echo ""
     fi
 


### PR DESCRIPTION
## Why

Codex Desktop may not inherit the interactive shell's `PATH`. The installers currently recommend:

```bash
codex mcp add fff -- fff-mcp
```

This can leave `fff` configured but unavailable because Codex cannot resolve `fff-mcp`.

## What changed

- Update the macOS/Linux and Windows installers to register the installed binary using its quoted absolute path.
- Add Codex setup examples for Homebrew and the one-line installer.
- Document the resulting `~/.codex/config.toml` entry and restart requirement.

## Verification

Confirmed that an installation path containing spaces produces:

```bash
codex mcp add fff -- "/private/tmp/fff path/bin/fff-mcp"
```

Also verified the Homebrew command creates:

```toml
[mcp_servers.fff]
command = "/opt/homebrew/bin/fff-mcp"
```

and successfully initializes the MCP server and performs a repository grep.