### PR TITLE
feat(download): accept explicit version in download_or_build_binary (#687)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,13 @@ https://github.com/user-attachments/assets/5d0e1ce9-642c-4c44-aa88-01b05bb86abb
 ```lua
 {
   'dmtrKovalenko/fff.nvim',
+  version = 'v0.10.0',
   build = function()
-    -- downloads a prebuilt binary or falls back to cargo build
-    require("fff.download").download_or_build_binary()
+    -- Downloads a prebuilt binary or falls back to `cargo build --release`.
+    -- Pass the same value you set as `version` above to guarantee the binary
+    -- matches the pinned Lua code. Omit to derive the tag from the checked-out
+    -- commit.
+    require("fff.download").download_or_build_binary({ version = 'v0.10.0' })
   end,
   -- for nixos:
   -- build = "nix run .#release",

--- a/lua/fff/download.lua
+++ b/lua/fff/download.lua
@@ -232,11 +232,23 @@ function M.build_binary(callback)
   end)
 end
 
-function M.download_or_build_binary()
+--- opts.version pins the GitHub release tag (accepts "0.10.0" or "v0.10.0").
+--- When omitted the tag is derived from the checked-out git ref.
+---@param opts? { version?: string, proxy?: string, extra_curl_args?: string[], timeout_ms?: integer }
+function M.download_or_build_binary(opts)
+  opts = opts or {}
+  local ensure_opts = { force = true, proxy = opts.proxy, extra_curl_args = opts.extra_curl_args }
+  if type(opts.version) == 'string' and opts.version ~= '' then
+    local v = opts.version
+    -- Stable release tags are `v<semver>`; nightly/dev per-sha tags are unprefixed.
+    if v:match('^%d+%.%d+%.%d+$') then v = 'v' .. v end
+    ensure_opts.version = v
+  end
+
   local done = false
   local fatal_error = nil
 
-  M.ensure_downloaded({ force = true }, function(download_success, download_error)
+  M.ensure_downloaded(ensure_opts, function(download_success, download_error)
     if download_success then
       done = true
       return
@@ -267,7 +279,7 @@ function M.download_or_build_binary()
   -- and if Neovim exits before the final rename(tmp → libfff_nvim.{dylib,so,dll})
   -- executes, the binary is never written to disk.  vim.wait pumps the event
   -- loop so all vim.system / vim.schedule callbacks can fire.
-  local timeout_ms = 1000 * 60 * 2 -- 2 minutes
+  local timeout_ms = opts.timeout_ms or (1000 * 60 * 2) -- default: 2 minutes
   local ok, wait_err = vim.wait(timeout_ms, function() return done end, 100)
   if not ok and wait_err == -2 then error('fff.nvim: download_or_build_binary timed out') end
 


### PR DESCRIPTION
Closes #687

## Root cause
`lua/fff/download.lua:235` `download_or_build_binary()` derives the download tag from `git tag --points-at HEAD` via `fff.utils.version.current_release_tag` (`lua/fff/utils/version.lua:33`). A release commit can carry several tags (e.g. `31be224` has `v0.10.0`, `0.9.7-nightly.a9df55d`, and `0.10.1-nightly.31be224`), and if lazy.nvim's shallow fetch does not bring the `v*` tag into the local repo the resolver falls through to a `-nightly` tag or to `M.resolve()`, which then constructs a nightly tag that may not have a matching release yet. Result: user pins `version = "0.10.0"` in lazy but the build hook downloads `0.10.1-nightly.<sha>`, which sometimes 404s.

## Fix
Expose an optional `opts` table on `download_or_build_binary({ version = ..., proxy = ..., extra_curl_args = ..., timeout_ms = ... })`. When `version` is set, `ensure_downloaded` receives it verbatim (bypassing the tag/HEAD heuristic). Accepts `"0.10.0"` or `"v0.10.0"` — a leading `v` is added only for `^%d+%.%d+%.%d+$` inputs so `nightly` / per-sha tags pass through untouched. `timeout_ms` is exposed too so users on slow hardware can raise the 2-minute cargo fallback ceiling reported in the issue (M1 Pro cold build ~6m40s). All params are optional — existing `download_or_build_binary()` callers are unaffected.

## Steps to reproduce
Setup on `origin/main` (pre-fix):
```lua
{
  'dmtrKovalenko/fff.nvim',
  version = 'v0.10.0',
  build = function()
    require('fff.download').download_or_build_binary()
  end,
}
```
Add `error('url: ' .. url)` right after the `url = string.format(...)` line at `lua/fff/download.lua:89`. Restart Neovim so lazy re-runs the build hook.

Expected: the error prints `https://github.com/dmtrKovalenko/fff.nvim/releases/download/v0.10.0/...`.
Actual (reporter): prints `https://github.com/dmtrKovalenko/fff.nvim/releases/download/0.10.1-nightly.<sha>/...`, and the download then 404s because that per-sha release does not exist yet.

Root-cause the divergence with `git -C <lazy-checkout> tag --points-at HEAD` — if the output does not contain `v0.10.0`, `current_release_tag` cannot return it and the code falls through to `resolve()`.

## How verified
Parse check: `luac -p lua/fff/download.lua` → OK.

Behavioral check with a mocked `vim.system` that captures the outbound URL:
```
CASE_1_UNPREFIXED ("0.10.0")  → https://github.com/dmtrKovalenko/fff.nvim/releases/download/v0.10.0/aarch64-apple-darwin.dylib
CASE_2_PREFIXED  ("v0.10.0")  → https://github.com/dmtrKovalenko/fff.nvim/releases/download/v0.10.0/aarch64-apple-darwin.dylib
CASE_3_NIGHTLY   ("nightly")  → https://github.com/dmtrKovalenko/fff.nvim/releases/download/nightly/aarch64-apple-darwin.dylib
```

Automated triage via Gustav. Honk-Honk 🪿