### PR TITLE
fix(watcher): stop ignored batches and small Flag::Rescan markers from breaking the index (#690)

### DIFF
--- a/crates/fff-core/src/watcher/background_watcher.rs
+++ b/crates/fff-core/src/watcher/background_watcher.rs
@@ -361,21 +361,16 @@ fn handle_debounced_events(
         }
 
         // When macOS FSEvents (or other backends) overflow their event buffer, the kernel
-        // drops individual events and emits a rescan flag telling us to re-scan the subtree
+        // drops individual events and emits a rescan flag telling us to re-scan the subtree.
+        // We must always schedule a rescan: skipping (even for a small path list) leaves the
+        // index inconsistent because the backend told us events were lost. Additionally on
+        // Linux an inotify Q_OVERFLOW arrives with no paths at all, which would previously
+        // hit a vacuous `all()` and be silently dropped.
         if debounced_event.event.need_rescan() {
-            if debounced_event.event.paths.len() < 16 // this should be usually one event
-                && debounced_event
-                    .paths
-                    .iter()
-                    // but we are smart enough and not falling into the paths
-                    .all(|p| !p.is_dir() && !filter.is_ignored(p))
-            {
-                break;
-            }
-
             warn!(
-                "Received rescan event for paths {:?}, triggering full rescan",
-                debounced_event.event.paths
+                paths = ?debounced_event.event.paths,
+                info = ?debounced_event.event.info(),
+                "Filesystem events were lost; scheduling full rescan",
             );
             need_full_rescan = true;
             break;
@@ -436,6 +431,7 @@ fn handle_debounced_events(
 
             if is_folder_removal {
                 dirs_to_remove.push(path.to_path_buf());
+                affected_paths_count += 1;
             } else if is_removed {
                 // best effort but doesn't require a stat and generally correct
                 let maybe_directory = !matches!(
@@ -444,6 +440,7 @@ fn handle_debounced_events(
                 );
 
                 paths_to_remove.push((path.as_path(), maybe_directory));
+                affected_paths_count += 1;
             } else if is_dir {
                 if !is_ignored {
                     new_dirs_to_watch.push(path.to_path_buf());
@@ -451,15 +448,18 @@ fn handle_debounced_events(
             } else if !is_ignored {
                 // For additions/modifications, still filter gitignored files.
                 paths_to_add_or_modify.push(path.as_path());
+                affected_paths_count += 1;
             }
         }
 
-        affected_paths_count += debounced_event.event.paths.len();
+        // Guard against pathological batches that would balloon the index. Only actionable
+        // paths (non-ignored, non-.git, non-directory-only) count — high-rate churn under
+        // an ignored subtree (e.g. `target/`) must NOT force a full rescan.
         if affected_paths_count > MAX_OVERFLOW_FILES {
             warn!(
                 ?affected_paths_count,
                 max = MAX_OVERFLOW_FILES,
-                "Too many affected paths in a single batch, triggering full rescan",
+                "Too many actionable paths in a single batch, triggering full rescan",
             );
 
             need_full_rescan = true;
@@ -879,7 +879,7 @@ mod tests {
     use crate::file_picker::{FilePicker, FilePickerOptions};
     use crate::watch::{WatchEvent, WatchOptions};
     use notify::Event;
-    use notify::event::{CreateKind, DataChange, ModifyKind, RemoveKind};
+    use notify::event::{CreateKind, DataChange, Flag, ModifyKind, RemoveKind};
     use std::sync::mpsc;
     use std::time::{Duration, Instant};
 
@@ -945,6 +945,199 @@ mod tests {
         assert_eq!(received.len(), 1);
         assert_eq!(received[0].path, path);
         assert_eq!(received[0].kind, WatchEventKind::Modified);
+    }
+
+    fn init_repo_picker_with_ignored_target(
+        base: &Path,
+    ) -> (SharedFilePicker, SharedFrecency, PathBuf) {
+        std::fs::write(base.join(".gitignore"), "/target\n").unwrap();
+        git2::Repository::init(base).unwrap();
+        let target = base.join("target");
+        std::fs::create_dir_all(&target).unwrap();
+
+        let shared_picker = SharedFilePicker::default();
+        let shared_frecency = SharedFrecency::noop();
+        let mut picker = FilePicker::new(FilePickerOptions {
+            base_path: base.to_string_lossy().into_owned(),
+            watch: false,
+            ..Default::default()
+        })
+        .unwrap();
+        picker.collect_files().unwrap();
+        shared_picker.rebase_watches(base);
+        *shared_picker.write().unwrap() = Some(picker);
+
+        (shared_picker, shared_frecency, target)
+    }
+
+    #[test]
+    fn ignored_batch_does_not_trigger_full_rescan() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = crate::path_utils::canonicalize(tmp.path()).unwrap();
+        let (shared_picker, shared_frecency, target) = init_repo_picker_with_ignored_target(&base);
+
+        let (sender, receiver) = mpsc::channel::<Vec<WatchEvent>>();
+        shared_picker
+            .watch_registry()
+            .subscribe(
+                &base,
+                "**",
+                WatchOptions::default(),
+                Box::new(move |_, events| {
+                    let _ = sender.send(events.to_vec());
+                }),
+            )
+            .unwrap();
+
+        // 2000 create events under ignored `target/`. Previously each counted
+        // toward MAX_OVERFLOW_FILES = 1024 and forced a Rescan dispatch.
+        let now = Instant::now();
+        let events: Vec<DebouncedEvent> = (0..2000)
+            .map(|i| {
+                let p = target.join(format!("f{i}.rs"));
+                std::fs::write(&p, "x").unwrap();
+                DebouncedEvent::new(
+                    Event::new(EventKind::Create(CreateKind::File)).add_path(p),
+                    now,
+                )
+            })
+            .collect();
+
+        handle_debounced_events(
+            FFFMode::Neovim,
+            events,
+            &base,
+            &Some(base.clone()),
+            &shared_picker,
+            &shared_frecency,
+            &GitStatusWorker::new(),
+        );
+
+        // No subscriber events at all — the batch is entirely ignored.
+        let got = receiver.recv_timeout(Duration::from_millis(200));
+        assert!(
+            got.is_err(),
+            "ignored batch must not dispatch any events (got {:?})",
+            got
+        );
+    }
+
+    #[test]
+    fn rescan_flag_still_triggers_rescan_when_batch_is_small() {
+        let tmp = tempfile::tempdir().unwrap();
+        let base = crate::path_utils::canonicalize(tmp.path()).unwrap();
+        let existing = base.join("existing.rs");
+        std::fs::write(&existing, "x").unwrap();
+
+        let shared_picker = SharedFilePicker::default();
+        let shared_frecency = SharedFrecency::noop();
+        let mut picker = FilePicker::new(FilePickerOptions {
+            base_path: base.to_string_lossy().into_owned(),
+            watch: false,
+            ..Default::default()
+        })
+        .unwrap();
+        picker.collect_files().unwrap();
+        shared_picker.rebase_watches(&base);
+        *shared_picker.write().unwrap() = Some(picker);
+
+        let (sender, receiver) = mpsc::channel::<Vec<WatchEvent>>();
+        shared_picker
+            .watch_registry()
+            .subscribe(
+                &base,
+                "**",
+                WatchOptions::default(),
+                Box::new(move |_, events| {
+                    let _ = sender.send(events.to_vec());
+                }),
+            )
+            .unwrap();
+
+        // A rescan marker on a single non-ignored, non-dir path used to be
+        // silently swallowed (the < 16 bypass). It must always trigger a
+        // full rescan now.
+        let now = Instant::now();
+        let events = vec![DebouncedEvent::new(
+            Event::new(EventKind::Other)
+                .add_path(existing.clone())
+                .set_flag(Flag::Rescan),
+            now,
+        )];
+
+        handle_debounced_events(
+            FFFMode::Neovim,
+            events,
+            &base,
+            &None,
+            &shared_picker,
+            &shared_frecency,
+            &GitStatusWorker::new(),
+        );
+
+        let received = receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(
+            received.iter().any(|e| e.kind == WatchEventKind::Rescan),
+            "Flag::Rescan must dispatch a Rescan event, got {:?}",
+            received
+        );
+    }
+
+    #[test]
+    fn empty_path_rescan_flag_triggers_rescan() {
+        // Linux inotify Q_OVERFLOW arrives as EventKind::Other + Flag::Rescan
+        // with no paths. Previously `all()` was vacuously true and the marker
+        // was silently dropped.
+        let tmp = tempfile::tempdir().unwrap();
+        let base = crate::path_utils::canonicalize(tmp.path()).unwrap();
+
+        let shared_picker = SharedFilePicker::default();
+        let shared_frecency = SharedFrecency::noop();
+        let mut picker = FilePicker::new(FilePickerOptions {
+            base_path: base.to_string_lossy().into_owned(),
+            watch: false,
+            ..Default::default()
+        })
+        .unwrap();
+        picker.collect_files().unwrap();
+        shared_picker.rebase_watches(&base);
+        *shared_picker.write().unwrap() = Some(picker);
+
+        let (sender, receiver) = mpsc::channel::<Vec<WatchEvent>>();
+        shared_picker
+            .watch_registry()
+            .subscribe(
+                &base,
+                "**",
+                WatchOptions::default(),
+                Box::new(move |_, events| {
+                    let _ = sender.send(events.to_vec());
+                }),
+            )
+            .unwrap();
+
+        let now = Instant::now();
+        let events = vec![DebouncedEvent::new(
+            Event::new(EventKind::Other).set_flag(Flag::Rescan),
+            now,
+        )];
+
+        handle_debounced_events(
+            FFFMode::Neovim,
+            events,
+            &base,
+            &None,
+            &shared_picker,
+            &shared_frecency,
+            &GitStatusWorker::new(),
+        );
+
+        let received = receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(
+            received.iter().any(|e| e.kind == WatchEventKind::Rescan),
+            "empty-path Flag::Rescan must dispatch a Rescan event, got {:?}",
+            received
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #690

## Root cause

Two independent bugs in `handle_debounced_events` (`crates/fff-core/src/watcher/background_watcher.rs`):

1. `affected_paths_count` summed raw `debounced_event.event.paths.len()` at `background_watcher.rs:457` before ignore filtering. A burst of >1024 events under an ignored subtree (e.g. `target/` churn from rustdoc / cargo build on macOS FSEvents recursive stream) forced a full rescan even though every path was filtered out at `background_watcher.rs:451-453`.
2. The `paths.len() < 16 && all(!is_dir && !is_ignored)` bypass at `background_watcher.rs:365-374` silently `break`ed out of the event loop on `Flag::Rescan` without scheduling a rescan and without processing later events in the batch. On Linux, inotify `Q_OVERFLOW` arrives with no paths at all, so `all()` was vacuously true and every overflow marker was dropped on the floor. On macOS, any batch of <16 small non-ignored paths hit the same bypass.

## Fix

- Count only actionable paths (those actually pushed to `paths_to_remove` / `dirs_to_remove` / `paths_to_add_or_modify`) against `MAX_OVERFLOW_FILES`. Ignored churn no longer trips the guard.
- Always schedule a full rescan on `need_rescan()`. Log `event.info()` alongside the paths so `user dropped` vs `kernel dropped` is distinguishable.

Architectural fix #2 from the issue (adaptive vs unconditional recursive FSEvents strategy) is intentionally out of scope — it needs benchmarking and a public strategy knob.

## Steps to reproduce

Trigger 1 (ignored batch → false rescan):

\`\`\`sh
# Any recursively watched macOS repo with .gitignore containing /target
cargo doc --workspace   # or any rustdoc generator producing many .js under target/doc
# fff-search emits: \"Too many affected paths in a single batch, triggering full rescan\"
# affected_paths_count = 1025, exactly matching the > 1024 branch,
# even though every path is under /target and filtered out of the index.
\`\`\`

Trigger 2 (silent `Flag::Rescan` bypass): unit-testable directly. On pre-fix `main`:

\`\`\`sh
cd crates/fff-core
# Feed a batch containing a single non-ignored, non-dir path with Flag::Rescan set.
# Expected: watch_registry dispatches a Rescan event.
# Actual: handler `break`s out early; subscribers never see the rescan.
\`\`\`

Both triggers are covered by unit tests added in this PR:

- `ignored_batch_does_not_trigger_full_rescan` — 2000 `Create(File)` events under `.gitignore`d `target/` must not dispatch a `Rescan`.
- `rescan_flag_still_triggers_rescan_when_batch_is_small` — a single-path `Flag::Rescan` must dispatch a `Rescan`.
- `empty_path_rescan_flag_triggers_rescan` — the Linux `Q_OVERFLOW` shape (empty path list) must dispatch a `Rescan`.

All three tests fail on `origin/main` (bug 1 dispatches a spurious rescan; bugs 2/3 silently return with no dispatch).

## How verified

\`\`\`sh
cargo test -p fff-search --lib background_watcher
# 5 passed; 0 failed — includes 3 new regression tests.

cargo test -p fff-search --lib
# 127 passed; 0 failed.

cargo test -p fff-search --test watch_subscription_test
# 11 passed; 0 failed.

cargo test -p fff-search --test new_directory_watcher_test
# 5 passed; 0 failed.

cargo fmt --package fff-search --check
# clean
\`\`\`

Automated triage via Gustav. Honk-Honk 🪿