### PR TITLE
fix(pi-fff): install fff-bun so bun runtimes can load the SDK (#689)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,10 +10,6 @@
     "packages/fff-bun": {
       "name": "@ff-labs/fff-bun",
       "version": "0.1.37",
-      "bin": {
-        "fff-demo": "./examples/search.ts",
-        "fff-grep": "./examples/grep.ts",
-      },
       "devDependencies": {
         "@types/bun": "^1.3.8",
         "typescript": "^5.0.0",
@@ -54,6 +50,7 @@
       "name": "@ff-labs/pi-fff",
       "version": "0.6.0",
       "dependencies": {
+        "@ff-labs/fff-bun": "*",
         "@ff-labs/fff-node": "*",
       },
       "devDependencies": {
@@ -63,12 +60,8 @@
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": "*",
         "@earendil-works/pi-tui": "*",
-        "@ff-labs/fff-bun": "*",
         "@sinclair/typebox": "*",
       },
-      "optionalPeers": [
-        "@ff-labs/fff-bun",
-      ],
     },
   },
   "packages": {

--- a/packages/pi-fff/package.json
+++ b/packages/pi-fff/package.json
@@ -40,18 +40,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ff-labs/fff-bun": "*",
     "@ff-labs/fff-node": "*"
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*",
-    "@ff-labs/fff-bun": "*",
     "@sinclair/typebox": "*"
-  },
-  "peerDependenciesMeta": {
-    "@ff-labs/fff-bun": {
-      "optional": true
-    }
   },
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
Closes #689

## Root cause

PR #669 (commit d1dac82) added a runtime bun/node switch in `packages/pi-fff/src/sdk.ts:26` that dynamically imports `@ff-labs/fff-bun` when running under bun. The same PR declared `@ff-labs/fff-bun` as an *optional* peer dependency in `packages/pi-fff/package.json:48-55`. Package managers do not install optional peers by default, so `pi install npm:@ff-labs/pi-fff` on a bun-only host produces a `node_modules` tree containing `@ff-labs/fff-node` but not `@ff-labs/fff-bun`, and pi crashes at `session_start` with `Cannot find module '@ff-labs/fff-bun'`.

## Fix

Promote `@ff-labs/fff-bun` from optional peer to a regular dependency alongside `@ff-labs/fff-node` in `packages/pi-fff/package.json`. Bundle-size cost is minor — both SDKs are thin TS shims over the same optional native `@ff-labs/fff-bin-*` binaries — and this guarantees the dynamic import in `sdk.ts` always resolves regardless of runtime or which installer pi uses. `bun.lock` regenerated accordingly.

## Steps to reproduce

Reproduce on `origin/main` (pre-fix) on any host with bun and no global node:

```sh
bun i -g @earendil-works/pi-coding-agent
pi install npm:@ff-labs/pi-fff

# Confirm the missing dep:
grep -c '"@ff-labs/fff-bun"' ~/.pi/agent/npm/bun.lock   # → 0

pi
```

Expected: pi starts, `session_start` succeeds, `ffgrep`/`fffind` tools available.

Actual (pre-fix):
```
Error: FFF init failed: ResolveMessage: Cannot find module '@ff-labs/fff-bun' from '/home/<user>/.pi/agent/npm/node_modules/@ff-labs/pi-fff/src/sdk.ts'
```

Confirmed by three independent reporters (Debian, mise, Windows/scoop) in issue #689, all sharing `bun` as the runtime.

## How verified

Simulated a fresh install of the fixed package into an empty project against a bun-only host:

```sh
mkdir /tmp/pi-fff-test && cd /tmp/pi-fff-test
cat > package.json <<'JSON'
{ "dependencies": { "@ff-labs/pi-fff": "file:.../packages/pi-fff" } }
JSON
bun install
ls node_modules/@ff-labs/
# → fff-bin-darwin-arm64  fff-bun  fff-node  pi-fff   (fff-bun now present)
```

Also ran:
```sh
cd packages/fff-node && bun run build   # OK
cd packages/pi-fff   && bun run typecheck # OK, no errors
```

Automated triage via Gustav. Honk-Honk 🪿