### PR TITLE
feat(npm): add Android arm64 (Termux) support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -183,6 +183,7 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-linux-android
             artifact_name: target/aarch64-linux-android/ci/libfff_c.so
+            npm_package: fff-bin-android-arm64
             lib_filename: libfff_c.so
             ext: so
 
@@ -273,7 +274,6 @@ jobs:
           mv "${{ matrix.artifact_name }}" "c-lib-${{ matrix.target }}.${{ matrix.ext }}"
 
       - name: Prepare npm package
-        if: "!contains(matrix.target, 'android')"
         shell: bash
         run: |
           # Copy the built binary into the platform npm package directory
@@ -286,7 +286,6 @@ jobs:
           path: c-lib-${{ matrix.target }}.*
 
       - name: Upload npm package artifact
-        if: "!contains(matrix.target, 'android')"
         uses: actions/upload-artifact@v4
         with:
           name: npm-${{ matrix.npm_package }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4102,7 +4102,8 @@
       "os": [
         "darwin",
         "linux",
-        "win32"
+        "win32",
+        "android"
       ],
       "devDependencies": {
         "@types/bun": "^1.3.8",
@@ -4112,6 +4113,7 @@
         "bun": ">=1.0.0"
       },
       "optionalDependencies": {
+        "@ff-labs/fff-bin-android-arm64": "0.0.0",
         "@ff-labs/fff-bin-darwin-arm64": "0.0.0",
         "@ff-labs/fff-bin-darwin-x64": "0.0.0",
         "@ff-labs/fff-bin-linux-arm64-gnu": "0.0.0",
@@ -4165,7 +4167,8 @@
       "os": [
         "darwin",
         "linux",
-        "win32"
+        "win32",
+        "android"
       ],
       "dependencies": {
         "ffi-rs": "^1.0.0"
@@ -4178,6 +4181,7 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
+        "@ff-labs/fff-bin-android-arm64": "0.0.0",
         "@ff-labs/fff-bin-darwin-arm64": "0.0.0",
         "@ff-labs/fff-bin-darwin-x64": "0.0.0",
         "@ff-labs/fff-bin-linux-arm64-gnu": "0.0.0",
@@ -4225,6 +4229,7 @@
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
+        "@ff-labs/fff-bun": "*",
         "@ff-labs/fff-node": "*"
       },
       "devDependencies": {

--- a/packages/fff-bin-android-arm64/package.json
+++ b/packages/fff-bin-android-arm64/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@ff-labs/fff-bin-android-arm64",
+  "version": "0.0.0",
+  "description": "fff native binary for Android ARM64 (Termux)",
+  "os": ["android"],
+  "cpu": ["arm64"],
+  "main": "libfff_c.so",
+  "files": ["libfff_c.so"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dmtrKovalenko/fff.git",
+    "directory": "packages/fff-bin-android-arm64"
+  }
+}

--- a/packages/fff-bun/package.json
+++ b/packages/fff-bun/package.json
@@ -27,7 +27,8 @@
   "os": [
     "darwin",
     "linux",
-    "win32"
+    "win32",
+    "android"
   ],
   "cpu": [
     "x64",
@@ -65,7 +66,8 @@
     "@ff-labs/fff-bin-linux-x64-musl": "0.0.0",
     "@ff-labs/fff-bin-linux-arm64-musl": "0.0.0",
     "@ff-labs/fff-bin-win32-x64": "0.0.0",
-    "@ff-labs/fff-bin-win32-arm64": "0.0.0"
+    "@ff-labs/fff-bin-win32-arm64": "0.0.0",
+    "@ff-labs/fff-bin-android-arm64": "0.0.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.8",

--- a/packages/fff-bun/src/platform.ts
+++ b/packages/fff-bun/src/platform.ts
@@ -14,6 +14,8 @@ export function getTriple(): string {
   let osName: string;
   if (platform === "darwin") {
     osName = "apple-darwin";
+  } else if (platform === "android") {
+    osName = "linux-android";
   } else if (platform === "linux") {
     osName = detectLinuxLibc();
   } else if (platform === "win32") {
@@ -107,6 +109,7 @@ const TRIPLE_TO_NPM_PACKAGE: Record<string, string> = {
   "aarch64-unknown-linux-musl": "@ff-labs/fff-bin-linux-arm64-musl",
   "x86_64-pc-windows-msvc": "@ff-labs/fff-bin-win32-x64",
   "aarch64-pc-windows-msvc": "@ff-labs/fff-bin-win32-arm64",
+  "aarch64-linux-android": "@ff-labs/fff-bin-android-arm64",
 };
 
 /**

--- a/packages/fff-node/package.json
+++ b/packages/fff-node/package.json
@@ -26,7 +26,8 @@
   "os": [
     "darwin",
     "linux",
-    "win32"
+    "win32",
+    "android"
   ],
   "cpu": [
     "x64",
@@ -67,7 +68,8 @@
     "@ff-labs/fff-bin-linux-x64-musl": "0.0.0",
     "@ff-labs/fff-bin-linux-arm64-musl": "0.0.0",
     "@ff-labs/fff-bin-win32-x64": "0.0.0",
-    "@ff-labs/fff-bin-win32-arm64": "0.0.0"
+    "@ff-labs/fff-bin-win32-arm64": "0.0.0",
+    "@ff-labs/fff-bin-android-arm64": "0.0.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/packages/fff-node/src/platform.ts
+++ b/packages/fff-node/src/platform.ts
@@ -14,6 +14,8 @@ export function getTriple(): string {
   let osName: string;
   if (platform === "darwin") {
     osName = "apple-darwin";
+  } else if (platform === "android") {
+    osName = "linux-android";
   } else if (platform === "linux") {
     osName = detectLinuxLibc();
   } else if (platform === "win32") {
@@ -109,6 +111,7 @@ const TRIPLE_TO_NPM_PACKAGE: Record<string, string> = {
   "aarch64-unknown-linux-musl": "@ff-labs/fff-bin-linux-arm64-musl",
   "x86_64-pc-windows-msvc": "@ff-labs/fff-bin-win32-x64",
   "aarch64-pc-windows-msvc": "@ff-labs/fff-bin-win32-arm64",
+  "aarch64-linux-android": "@ff-labs/fff-bin-android-arm64",
 };
 
 /**


### PR DESCRIPTION
Closes #692

## Root cause
`@ff-labs/fff-node` and `@ff-labs/fff-bun` declare `os: [darwin, linux, win32]`, so npm rejects Android installs with `EBADPLATFORM`. Even with `npm_config_force=true` no binary resolves because `TRIPLE_TO_NPM_PACKAGE` has no `aarch64-linux-android` entry and `getTriple()` throws on `process.platform === 'android'`. CI already cross-compiles `aarch64-linux-android` (`.github/workflows/release.yaml:182-187`, `245-256`) but the "Prepare npm package" and "Upload npm package artifact" steps were skipped, and no platform package existed.

## Fix
- New `packages/fff-bin-android-arm64/` with `os: [android]`, `cpu: [arm64]`.
- Map `process.platform === 'android'` → `linux-android` in `getTriple()` for both `fff-node` and `fff-bun`.
- Add `aarch64-linux-android` → `@ff-labs/fff-bin-android-arm64` in `TRIPLE_TO_NPM_PACKAGE` (both packages).
- Add `android` to `os` and the new package to `optionalDependencies` in `fff-node` and `fff-bun` `package.json`.
- Set `npm_package: fff-bin-android-arm64` on the android matrix leg and unskip the prepare/upload steps in `.github/workflows/release.yaml` so the existing NDK build gets published.

## Steps to reproduce
On Termux (Android arm64), on `main` before this fix:
```sh
pi install npm:@ff-labs/pi-fff
# npm error code EBADPLATFORM
# npm error notsup Unsupported platform for @ff-labs/fff-node@0.10.0:
#   wanted {"os":"darwin,linux,win32","cpu":"x64,arm64"}
#   (current: {"os":"android","cpu":"arm64"})
```
Workaround the reporter found (`npm_config_force=true pi install npm:@ff-labs/pi-fff`) bypasses the platform check but leaves `resolveFromNpmPackage()` returning `null` (`packages/fff-node/src/binary.ts:68`), so runtime `dlopen` still fails outside a dev workspace.

After this PR + first release cutting `@ff-labs/fff-bin-android-arm64`, the same command should succeed without `--force`, and `findBinary()` should return the `libfff_c.so` inside the android platform package.

## How verified
- `npm run typecheck` in `packages/fff-node` and `packages/fff-bun` — pass.
- `npm run build` in `packages/fff-node` — pass.
- CI android build path already existed and produced `target/aarch64-linux-android/ci/libfff_c.so`; only packaging wiring changed.
- No runtime verification on-device — @dmtrKovalenko + @joaothallis, please dogfood a nightly on Termux before tagging a release; if `ldd`/`dlopen` of `libfff_c.so` against Bionic surfaces an unresolved symbol, we may need to adjust `ffi-rs` handling (Termux uses `@yuuang/ffi-rs-android-arm64@1.3.2` which npm already selected in the reporter's log).

Automated triage via Gustav. Honk-Honk 🪿