### PR TITLE
fix(pi-fff): stop reopening main LMDB envs in aux finders (#700)

### DIFF
--- a/packages/pi-fff/src/aux-finders.ts
+++ b/packages/pi-fff/src/aux-finders.ts
@@ -14,8 +14,6 @@ interface AuxPicker {
 }
 
 export interface AuxOpts {
-  frecencyDbPath?: string;
-  historyDbPath?: string;
   enableFsRootScanning: boolean;
 }
 
@@ -69,10 +67,11 @@ export class AuxFinderPool {
     }
 
     const { FileFinder } = await loadSdk();
+    // LMDB env can only be opened once per process; the main finder already
+    // owns the frecency/history DBs. Aux finders are transient and run without
+    // persistent scoring — see issue #700.
     const result = FileFinder.create({
       basePath: maybeRoot,
-      frecencyDbPath: this.opts.frecencyDbPath,
-      historyDbPath: this.opts.historyDbPath,
       aiMode: true,
       enableHomeDirScanning: true,
       enableFsRootScanning: this.opts.enableFsRootScanning,

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -344,8 +344,6 @@ export default function fffExtension(pi: ExtensionAPI) {
   }
 
   let auxPool = new AuxFinderPool({
-    frecencyDbPath,
-    historyDbPath,
     enableFsRootScanning,
   });
 

--- a/packages/pi-fff/test/aux-pool.test.ts
+++ b/packages/pi-fff/test/aux-pool.test.ts
@@ -8,6 +8,7 @@ interface MockFinder {
 }
 
 const created: MockFinder[] = [];
+const createOptions: Record<string, unknown>[] = [];
 
 function createMockFinder(basePath: string): MockFinder {
   const finder: MockFinder = {
@@ -24,10 +25,13 @@ function createMockFinder(basePath: string): MockFinder {
 
 const finderModule = {
   FileFinder: {
-    create: (options: { basePath: string }) => ({
-      ok: true,
-      value: createMockFinder(options.basePath),
-    }),
+    create: (options: Record<string, unknown>) => {
+      createOptions.push(options);
+      return {
+        ok: true,
+        value: createMockFinder(options.basePath as string),
+      };
+    },
   },
 };
 
@@ -38,6 +42,7 @@ const { AuxFinderPool } = await import("../src/aux-finders");
 
 function makePool() {
   created.length = 0;
+  createOptions.length = 0;
   return new AuxFinderPool({ enableFsRootScanning: false });
 }
 
@@ -85,5 +90,18 @@ describe("AuxFinderPool covering reuse", () => {
     const other = await pool.acquire("/a/b");
     expect(other.root).toBe("/a/b");
     expect(created.length).toBe(2);
+  });
+
+  // Regression for #700: aux finders must not reopen the main frecency/history
+  // LMDB envs, or heed fails with "environment already open in this program".
+  test("aux finders are created without frecency/history db paths", async () => {
+    const pool = makePool();
+    await pool.acquire("/a/b/c");
+    await pool.acquire("/x/y");
+    expect(createOptions.length).toBe(2);
+    for (const opts of createOptions) {
+      expect(opts.frecencyDbPath).toBeUndefined();
+      expect(opts.historyDbPath).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
Closes #700

## Root cause
`AuxFinderPool.acquire` (`packages/pi-fff/src/aux-finders.ts:71-79`) forwarded the main finder's `frecencyDbPath` / `historyDbPath` into every `FileFinder.create` call. LMDB envs can only be opened once per process, so the first out-of-workspace search failed with `Failed to open frecency database env: environment already open in this program`.

## Fix
Drop `frecencyDbPath` / `historyDbPath` from `AuxOpts` and stop passing them when constructing aux finders. Aux finders are transient, per-search pickers and run without persistent frecency/history scoring; the main finder retains ownership of those DBs.

## Steps to reproduce

Reproducer with `@ff-labs/fff-node` (matches the reporter's finding):

```js
import { FileFinder } from "@ff-labs/fff-node";
const dbs = {
  frecencyDbPath: "/tmp/fff/frecency.mdb",
  historyDbPath: "/tmp/fff/history.mdb",
};
const a = FileFinder.create({ basePath: "/tmp/ws", ...dbs });
console.log(a.ok); // true

const b = FileFinder.create({ basePath: "/tmp/elsewhere", ...dbs });
console.log(b.ok, b.error);
// false, Failed to init frecency db: Failed to open frecency database env:
//        environment already open in this program; close it to be able to
//        open it again with different options
```

End-to-end via pi-fff: set `FFF_FRECENCY_DB` / `FFF_HISTORY_DB`, launch `@ff-labs/pi-fff@0.10.1` in a workspace, then trigger a search that routes to an aux finder (absolute path outside the workspace, or a `../elsewhere` constraint). The aux acquire fails with `Failed to create aux file finder for <root>: Failed to init frecency db: ...`.

Expected: aux search completes and persistent frecency/history stay enabled on the main finder.

## How verified
- `bun test` in `packages/pi-fff/` — 45 pass, 0 fail. Added regression test `aux finders are created without frecency/history db paths` in `packages/pi-fff/test/aux-pool.test.ts` asserting `AuxFinderPool.acquire` never forwards DB paths to `FileFinder.create`.

Automated triage via Gustav. Honk-Honk 🪿