### PR TITLE
fix(pi-fff): pin SDK dependencies during publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,9 @@ set-npm-version:
 				pkg.optionalDependencies[dep] = '$(VERSION)'; \
 			} \
 		} \
+		for (const dep of ['@ff-labs/fff-bun', '@ff-labs/fff-node']) { \
+			if (pkg.dependencies?.[dep]) pkg.dependencies[dep] = '$(VERSION)'; \
+		} \
 		fs.writeFileSync('$(PKG)/package.json', JSON.stringify(pkg, null, 2) + '\n'); \
 	"
 	@echo "Set $(PKG) to $(VERSION)"


### PR DESCRIPTION
## Description

`@ff-labs/pi-fff` is published with wildcard dependencies on `@ff-labs/fff-node` and `@ff-labs/fff-bun`. An existing npm lockfile can therefore retain an older SDK and native binary after `pi-fff` itself is updated, leaving Pi exposed to native bugs fixed in the matching release.

Extend the existing `set-npm-version` release step to set both SDK dependencies to the release version. Published `pi-fff` packages will then require the matching Node and Bun SDK/native release instead of accepting any version.

Fixes #710.

## Steps to Reproduce Bug and Validate Solution

### Reproduce

1. Install an older `@ff-labs/fff-node` through `@ff-labs/pi-fff` and retain the npm lockfile.
2. Update `@ff-labs/pi-fff` to `0.10.1`.
3. Observe that npm can keep the older Node/native dependency because the published manifest specifies `"@ff-labs/fff-node": "*"`.

A real installation retained `fff-node` and `fff-bin-darwin-arm64` 0.9.3 while `pi-fff` and the Bun SDK were 0.10.1. Two Pi processes subsequently blocked in `fff_live_grep` / `parking_lot::RawRwLock` native frames.

### Validate

1. Run `make set-npm-version` with `VERSION=9.8.7` against temporary copies of `pi-fff`, `fff-node`, and `fff-bun` manifests.
2. Assert that both `pi-fff` SDK dependencies become `9.8.7`, platform optional dependencies still become `9.8.7`, and unrelated `fff-node` dependencies remain unchanged.
3. Run `bun test packages/pi-fff/test`.

## PR Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All relevant new and existing tests passed.
- [x] My code follows the code style of this project.
- [ ] I ran lint checks with no new errors or warnings.
- [x] I checked for other open pull requests for the same change.

## Does This Introduce a Breaking Change?

- [ ] Yes
- [x] No

## Testing

- **OS/environment:** macOS arm64; Bun 1.3.14; Node 24
- **Commands/checks:** temporary-manifest `make set-npm-version` assertions; `bun test packages/pi-fff/test`; `git diff --check`
- **Results:** version assertions passed; 45 tests passed, 0 failed; diff check passed
- **Scenarios covered:** `pi-fff` direct SDK dependency synchronization, existing platform optional-dependency synchronization, and preservation of unrelated dependencies

## Other Information or Known Dependencies

The full npm publication workflow was not run locally because it requires release credentials and built platform artifacts. Lint was not run because the change only modifies the Makefile's existing inline manifest-rewrite script.
