### PR TITLE
fix(pi-fff): use exact aux finder for external paths

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -5,7 +5,6 @@
  * @-mention autocomplete suggestions to the interactive editor.
  */
 
-import nodePath from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   type AutocompleteItem,
@@ -404,15 +403,14 @@ export default function fffExtension(pi: ExtensionAPI) {
   ): Promise<{ finder: FileFinderApi; query: string; root: string } | null> {
     const route = routePathConstraint(pathParam, activeCwd);
     if (!route) return null;
-    const aux = await auxPool.acquire(route.root);
-    // A broader covering picker may have been reused; rebase the suffix so the
-    // constraint stays relative to the picker's actual root.
-    const rebase = nodePath
-      .relative(aux.root, route.root)
-      .replaceAll(nodePath.sep, "/");
-    const suffix = [rebase, route.suffix].filter(Boolean).join("/");
-    const query = buildQuery(suffix || undefined, pattern, exclude, aux.root);
-    return { finder: aux.finder, query, root: aux.root };
+    const aux = await auxPool.acquire(route.root, { exact: true });
+    const query = buildQuery(
+      route.suffix || undefined,
+      pattern,
+      exclude,
+      route.root,
+    );
+    return { finder: aux.finder, query, root: route.root };
   }
 
   async function getMentionItems(

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -1,17 +1,22 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 type MockFinder = {
   isDestroyed: boolean;
   waitForScan: ReturnType<typeof mock>;
   mixedSearch: ReturnType<typeof mock>;
+  grep: ReturnType<typeof mock>;
   destroy: ReturnType<typeof mock>;
 };
 
 const createCalls: unknown[] = [];
 let finders: MockFinder[] = [];
 let mixedSearchImpl: ((query: string, options: unknown) => unknown) | undefined;
+let grepMatchRoot: string | undefined;
 
-function createMockFinder(): MockFinder {
+function createMockFinder(basePath: string): MockFinder {
   return {
     isDestroyed: false,
     waitForScan: mock(async () => undefined),
@@ -28,6 +33,20 @@ function createMockFinder(): MockFinder {
         },
       };
     }),
+    grep: mock(() => {
+      const items =
+        basePath === grepMatchRoot
+          ? [
+              {
+                relativePath: "target.ts",
+                fileName: "target.ts",
+                lineContent: "issue711Token",
+                lineNumber: 1,
+              },
+            ]
+          : [];
+      return { ok: true, value: { items } };
+    }),
     destroy: mock(function (this: MockFinder) {
       this.isDestroyed = true;
     }),
@@ -38,7 +57,7 @@ const finderModule = {
   FileFinder: {
     create: mock((options: unknown) => {
       createCalls.push(options);
-      const finder = createMockFinder();
+      const finder = createMockFinder((options as { basePath: string }).basePath);
       finders.push(finder);
       return { ok: true, value: finder };
     }),
@@ -85,6 +104,7 @@ type EventHandler = (...args: any[]) => unknown;
 function createPi(mode?: string) {
   const events = new Map<string, EventHandler>();
   const commands = new Map<string, any>();
+  const tools = new Map<string, any>();
 
   const pi = {
     getFlag: mock((name: string) => (name === "fff-mode" ? mode : undefined)),
@@ -95,11 +115,13 @@ function createPi(mode?: string) {
       commands.set(name, command);
     }),
     registerFlag: mock(() => undefined),
-    registerTool: mock(() => undefined),
+    registerTool: mock((tool: any) => {
+      tools.set(tool.name, tool);
+    }),
     appendEntry: mock(() => undefined),
   };
 
-  return { pi, events, commands };
+  return { pi, events, commands, tools };
 }
 
 function createContext() {
@@ -143,6 +165,7 @@ beforeEach(() => {
   createCalls.length = 0;
   finders = [];
   mixedSearchImpl = undefined;
+  grepMatchRoot = undefined;
   delete process.env.PI_FFF_MODE;
 });
 
@@ -320,5 +343,34 @@ describe("pi-fff autocomplete registration", () => {
     expect(shouldTrigger).toBe(false);
     expect(current.applyCompletion).toHaveBeenCalledTimes(1);
     expect(current.shouldTriggerFileCompletion).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("pi-fff external paths", () => {
+  test("uses an exact finder for an explicit external file", async () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "fff-711-"));
+    const broadRoot = path.join(fixture, ".pi");
+    const targetDir = path.join(broadRoot, "node_modules", "pkg");
+    const targetPath = path.join(targetDir, "target.ts");
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.writeFileSync(targetPath, "issue711Token\n");
+
+    try {
+      grepMatchRoot = targetDir;
+      const { tools } = await start();
+      const grep = tools.get("ffgrep");
+      await grep.execute("warmup", { pattern: "warmup", path: broadRoot });
+      const result = await grep.execute("repro", {
+        pattern: "issue711Token",
+        path: targetPath,
+      });
+
+      expect(result.content[0].text).toContain("target.ts");
+      expect(
+        createCalls.map((call) => (call as { basePath: string }).basePath),
+      ).toContain(targetDir);
+    } finally {
+      fs.rmSync(fixture, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Closes #711.

## Root cause

`resolveFinderForPath()` reused any cached auxiliary finder whose root covered the requested `route.root`.

A broader finder such as `~/.pi` can exclude nested directories like `node_modules` while building its index. Rebasing the query suffix relative to that broader root cannot recover files that were never indexed. When the exact search returned no matches, fuzzy fallback could also return unrelated files from the broader index.

## Fix

Acquire the exact requested auxiliary root for explicit paths outside the workspace:

```ts
const aux = await auxPool.acquire(route.root, { exact: true });
```

Since exact acquisition guarantees that the finder is rooted at `route.root`, build the query directly from `route.suffix` and remove the obsolete ancestor-root rebasing logic.

Add an extension-level regression test that first caches a broader finder, then searches an absolute file path under its ignored `node_modules` subtree. The test verifies that a finder rooted at the target directory is created and the requested file is returned.

## Steps to reproduce

Start Pi in a workspace outside `~/.pi`, ensure an auxiliary finder rooted at `~/.pi` has already been cached, then run:

```json
{
  "pattern": "randomUUID",
  "path": "/Users/example/.pi/agent/npm/node_modules/@tintinweb/pi-subagents/src/agent-manager.ts",
  "limit": 3
}
```

- Pre-fix: the cached `~/.pi` finder is reused, but its index excludes `node_modules`; the requested file is missed and fuzzy fallback may return unrelated files.
- Post-fix: a finder rooted at the target file's directory is created or reused, and matches from the requested file are returned.

## How verified

- `cd packages/pi-fff && bun test test/extension.test.ts` — 9 passed
- `cd packages/pi-fff && bun run typecheck`

The full pi-fff suite on Windows reported 38 passed and 9 existing failures in `aux-finders.test.ts` and `aux-pool.test.ts`; those tests use hard-coded POSIX paths such as `/tmp` and `/a/b`.