### PR TITLE
feat(fff.nvim): accept custom border character arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,11 @@ require('fff').setup({
     -- Border style for the picker windows. Leave unset (nil) to follow the
     -- global `vim.o.winborder`; set it to override fff's borders independently.
     border = nil, -- 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'none'
+    -- border = {
+    --   { ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ' },
+    --   { ' ', ' ', ' ', ' ', ' ', ' ' },
+    -- },
+
     flex = { size = 130, wrap = 'top' },
     min_list_height = 10, --  do not display anything except the list below this threshold
     show_scrollbar = true,

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -9,7 +9,7 @@ local M = {}
 --- @field min_list_height number
 --- @field show_scrollbar boolean
 --- @field path_shorten_strategy string
---- @field border? 'single'|'double'|'rounded'|'solid'|'shadow'|'none' Border preset; falls back to `vim.o.winborder` when nil
+--- @field border? 'single'|'double'|'rounded'|'solid'|'shadow'|'none'|table<string[],string[]> Border preset; falls back to `vim.o.winborder` when nil
 
 --- @class FffPreviewConfig
 --- @field enabled boolean

--- a/lua/fff/layout.lua
+++ b/lua/fff/layout.lua
@@ -29,6 +29,9 @@ local function get_border_chars(config)
   if border == nil or border == '' then border = vim.o.winborder end
   if border == nil or border == '' then border = 'single' end
 
+  if type(border) == 'table' then
+    if #border == 2 and type(border[1]) == 'table' and type(border[2]) == 'table' then return border[1], border[2] end
+  end
   if BORDER_PRESETS[border] then return BORDER_PRESETS[border], T_JUNCTION_PRESETS[border] end
   return BORDER_PRESETS.single, T_JUNCTION_PRESETS.single
 end


### PR DESCRIPTION
Allow users to pass a custom border table instead of just preset strings. Supports a table { border_chars, junction_chars } and falls back to existing preset system when a string is passed

I added an example of my usecase / how to use it in the README, I am not sure how you would want to present this information.