### PR TITLE
feat(mcp): expose home and fs root scanning options

### DIFF
--- a/crates/fff-mcp/src/main.rs
+++ b/crates/fff-mcp/src/main.rs
@@ -154,6 +154,30 @@ pub(crate) struct Args {
     #[arg(long = "follow-symlinks")]
     follow_symlinks: bool,
 
+    /// Allow indexing the user's home directory. FFF refuses to init in `~`
+    /// unless this is set. Also settable via FFF_ENABLE_HOME_SCAN=1.
+    #[arg(
+        long = "enable-home-scan",
+        env = "FFF_ENABLE_HOME_SCAN",
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = false,
+        value_parser = clap::builder::BoolishValueParser::new()
+    )]
+    enable_home_scan: bool,
+
+    /// Allow indexing the filesystem root, off by default for the same reason.
+    /// Also settable via FFF_ENABLE_ROOT_SCAN=1.
+    #[arg(
+        long = "enable-root-scan",
+        env = "FFF_ENABLE_ROOT_SCAN",
+        num_args = 0..=1,
+        default_missing_value = "true",
+        default_value_t = false,
+        value_parser = clap::builder::BoolishValueParser::new()
+    )]
+    enable_root_scan: bool,
+
     /// Run a health check and print diagnostic information, then exit.
     #[arg(long = "healthcheck")]
     pub(crate) healthcheck: bool,
@@ -276,7 +300,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .max_cached_files
                 .map(fff::ContentCacheBudget::new_for_repo),
             follow_symlinks: args.follow_symlinks,
-            ..Default::default()
+            enable_home_dir_scanning: args.enable_home_scan,
+            enable_fs_root_scanning: args.enable_root_scan,
         },
     )
     .map_err(|e| format!("Failed to init file picker: {}", e))?;


### PR DESCRIPTION
Closes #588 for the MCP surface.

`fff-core` gates indexing of `$HOME` and `/` behind `enable_home_dir_scanning` and `enable_fs_root_scanning`. Every surface exposes them except `fff-mcp`, which builds `FilePickerOptions { .., ..Default::default() }` and so leaves both `false` with no way to change them:

| Surface | Exposes it |
|---|---|
| `crates/fff-c/src/lib.rs` | yes |
| `crates/fff-python/src/finder.rs` | yes |
| `crates/fff-nvim/src/lib.rs` | yes |
| `packages/shared/fff-api.ts` (node/bun) | yes |
| `crates/fff-mcp/src/main.rs` | no |

The result is that fff-mcp aborts at startup whenever an editor or agent launches it from a home directory:

```
$ cd ~ && fff-mcp
Error: "Failed to init file picker: Can not run certain FFF features in a file
system root or home directories. Consider smaller per-project directories."
```

MCP clients spawn the server with their own cwd, which is frequently `~`, so the server is simply unusable there.

Adds `--enable-home-scan` and `--enable-root-scan`, also settable via `FFF_ENABLE_HOME_SCAN` and `FFF_ENABLE_ROOT_SCAN`. `FFF_ENABLE_ROOT_SCAN` is the same variable `pi-fff` already reads (ec57eb02), so one export covers both. Values use clap's boolish parser, accepting `1`/`0`/`true`/`false`, matching the `=1` form used in #588 and pi-fff.

Both default to `false`, so the guard is unchanged unless explicitly opted into.

## Verified

- Guard still refuses from `~` by default
- `--enable-home-scan` and `FFF_ENABLE_HOME_SCAN=1` each enable it
- `FFF_ENABLE_HOME_SCAN=0` keeps the guard, and the flag overrides the env
- `/` stays refused unless `--enable-root-scan`; `--enable-home-scan` alone does not unlock it
- Normal repositories are unaffected
- `cargo fmt` and `cargo clippy` clean
