### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ require('fff').setup({
     border = nil, -- 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | 'none'
     -- border = {
     --   { ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ' },
-    --   { ' ', ' ', ' ', ' ', ' ', ' ' },
+    --   { ' ', ' ', ' ', ' ', ' ' },
     -- },
 
     flex = { size = 130, wrap = 'top' },


### PR DESCRIPTION
My apologies, I didn't realize until after my last PR #715 was merged, in my README example I used 6 characters for the border junction array instead of the proper 5.