### PR TITLE
fix(score): rank exact filename stem match above fuzzy filename (#722)

### DIFF
--- a/crates/fff-core/src/score.rs
+++ b/crates/fff-core/src/score.rs
@@ -753,28 +753,37 @@ fn match_and_score_in_arena<'a>(
 
             let is_filename_match = end_col_filename_match || simd_filename_match.is_some();
             let fname_len = file.path.byte_len as usize - file.path.filename_offset as usize;
+            let needle_len = main_needle_len as usize;
 
-            let is_exact_filename = simd_filename_match.is_some_and(|m| m.exact)
-                || (end_col_filename_match && main_needle_len as usize == fname_len && {
-                    file.write_file_name_from_arena(arena, &mut fname_buf);
-                    main_needle.eq_ignore_ascii_case(fname_buf.as_bytes())
-                });
-
-            // Exact stem match: needle equals the filename's stem (bytes before
-            // the last dot). Ranks between fuzzy_filename and exact_filename so
-            // e.g. `lsp` prefers `lsp.lua` over `lsp/typos_lsp.lua`.
-            let is_exact_stem = !is_exact_filename
-                && is_filename_match
-                && (main_needle_len as usize + 2) <= fname_len
-                && {
+            // Length-gated exact-filename / exact-stem detection: both variants
+            // are mutually exclusive by length (exact needs n == fname_len, stem
+            // needs n + 2 <= fname_len), so the arena read happens at most once
+            // and is skipped when neither is plausible. Reuses `fname_buf` to
+            // avoid a per-file allocation.
+            let (is_exact_filename, is_exact_stem) = if !is_filename_match {
+                (false, false)
+            } else if simd_filename_match.is_some_and(|m| m.exact) {
+                (true, false)
+            } else {
+                let could_be_exact = end_col_filename_match && needle_len == fname_len;
+                let could_be_stem = needle_len + 2 <= fname_len;
+                if !could_be_exact && !could_be_stem {
+                    (false, false)
+                } else {
                     file.write_file_name_from_arena(arena, &mut fname_buf);
                     let bytes = fname_buf.as_bytes();
-                    let n = main_needle_len as usize;
-                    bytes.len() > n + 1
-                        && bytes[n] == b'.'
-                        && !bytes[n + 1..].contains(&b'.')
-                        && main_needle.eq_ignore_ascii_case(&bytes[..n])
-                };
+                    if could_be_exact {
+                        (main_needle.eq_ignore_ascii_case(bytes), false)
+                    } else if bytes[needle_len] == b'.'
+                        && !bytes[needle_len + 1..].contains(&b'.')
+                        && main_needle.eq_ignore_ascii_case(&bytes[..needle_len])
+                    {
+                        (false, true)
+                    } else {
+                        (false, false)
+                    }
+                }
+            };
 
             let mut has_special_filename_bonus = false;
             let filename_bonus = if is_exact_filename {

--- a/crates/fff-core/src/score.rs
+++ b/crates/fff-core/src/score.rs
@@ -760,9 +760,27 @@ fn match_and_score_in_arena<'a>(
                     main_needle.eq_ignore_ascii_case(fname_buf.as_bytes())
                 });
 
+            // Exact stem match: needle equals the filename's stem (bytes before
+            // the last dot). Ranks between fuzzy_filename and exact_filename so
+            // e.g. `lsp` prefers `lsp.lua` over `lsp/typos_lsp.lua`.
+            let is_exact_stem = !is_exact_filename
+                && is_filename_match
+                && (main_needle_len as usize + 2) <= fname_len
+                && {
+                    file.write_file_name_from_arena(arena, &mut fname_buf);
+                    let bytes = fname_buf.as_bytes();
+                    let n = main_needle_len as usize;
+                    bytes.len() > n + 1
+                        && bytes[n] == b'.'
+                        && !bytes[n + 1..].contains(&b'.')
+                        && main_needle.eq_ignore_ascii_case(&bytes[..n])
+                };
+
             let mut has_special_filename_bonus = false;
             let filename_bonus = if is_exact_filename {
                 base_score / 5 * 2 // 40% bonus for exact filename match
+            } else if is_exact_stem {
+                base_score * 30 / 100 // 30% bonus for exact filename stem match
             } else if is_filename_match {
                 // 16% bonus for fuzzy filename match that landed in the filename region.
                 // For fallback matches (where the path match landed in a directory segment),
@@ -868,9 +886,11 @@ fn match_and_score_in_arena<'a>(
                 distance_penalty,
                 combo_match_boost,
                 path_alignment_bonus,
-                exact_match: is_exact_filename || path_match.exact,
+                exact_match: is_exact_filename || is_exact_stem || path_match.exact,
                 match_type: if is_exact_filename {
                     "exact_filename"
+                } else if is_exact_stem {
+                    "exact_stem"
                 } else if is_filename_match {
                     "fuzzy_filename"
                 } else if path_match.exact {
@@ -1391,6 +1411,24 @@ mod filename_bonus_tests {
             results[1].1.match_type, "exact_filename",
             "file.rs should not get exact_filename"
         );
+    }
+
+    /// Regression: query that exactly matches the filename stem (name minus
+    /// extension) should rank clearly above files that just contain the query
+    /// as a fuzzy filename substring. https://github.com/dmtrKovalenko/fff/issues/722
+    #[test]
+    fn test_exact_stem_beats_fuzzy_filename() {
+        let (files, arena) = make_files(&["lsp/typos_lsp.lua", "lsp.lua"]);
+
+        let results = search(&files, "lsp", arena);
+
+        assert!(results.len() >= 2);
+        assert_eq!(
+            results[0].0, "lsp.lua",
+            "lsp.lua (exact filename stem) should rank above typos_lsp.lua"
+        );
+        assert_eq!(results[0].1.match_type, "exact_stem");
+        assert!(results[0].1.filename_bonus > results[1].1.filename_bonus);
     }
 
     #[test]


### PR DESCRIPTION
Closes #722

## Root cause

`crates/fff-core/src/score.rs:757` — `is_exact_filename` requires `main_needle_len == fname_len` and a case-insensitive equality against the ENTIRE filename (including extension). A query that exactly matches the filename stem (e.g. `lsp` ↔ `lsp.lua`) falls through into the `fuzzy_filename` branch capped at ~16% of `base_score`. `lsp.lua` (2-char subsequence in an 7-char filename) and `lsp/typos_lsp.lua` (2-char subsequence in a 13-char filename) both land there, differ by only 2 points, and any frecency/git bonus on the longer file flips the order.

## Fix

`crates/fff-core/src/score.rs` — add `is_exact_stem`: `true` when the needle equals the filename's stem (bytes before the LAST dot) and there is no additional dot beyond that. Awards a 30% `base_score` bonus, positioned between `fuzzy_filename` (~16%) and `exact_filename` (40%). Adds a new `match_type = "exact_stem"` and includes it in `exact_match`.

## Steps to reproduce

Add this unit test to `crates/fff-core/src/score.rs` inside `mod filename_bonus_tests` (uses the existing `make_files`/`search` helpers already in that module) and run against `origin/main`:

```rust
#[test]
fn issue_722_repro() {
    let (files, arena) = make_files(&["lsp/typos_lsp.lua", "lsp.lua"]);
    let results = search(&files, "lsp", arena);
    for (path, s) in &results {
        eprintln!("{} total={} bonus={} type={}", path, s.total, s.filename_bonus, s.match_type);
    }
    assert_eq!(results[0].0, "lsp.lua");
}
```

Run:

```sh
cargo test --lib --manifest-path crates/fff-core/Cargo.toml issue_722_repro -- --nocapture
```

Expected (bug): `lsp.lua total=56 bonus=8 type=fuzzy_filename` and `lsp/typos_lsp.lua total=54 bonus=6 type=fuzzy_filename`. Both files score as generic fuzzy matches; the 2-point gap is trivially overturned by any frecency/git bonus on `lsp/typos_lsp.lua`, causing it to rank first as the reporter observed in the screenshot.

## How verified

- New regression test `test_exact_stem_beats_fuzzy_filename` asserts `lsp.lua` ranks first with `match_type == "exact_stem"`.
- Full `cargo test --lib` in `crates/fff-core`: 125 passed, 0 failed.
- `make test` — all Rust + Lua + bun tests pass (pre-existing `tsc` env issue in `test-node` unrelated to change).

Post-fix output for the repro:

```
lsp.lua           total=127 bonus=27 type=exact_stem
lsp/typos_lsp.lua total=54  bonus=6  type=fuzzy_filename
```

Automated triage via Gustav. Honk-Honk 🪿