### PR TITLE
chore(deps): bump git2 to 0.21.0 to clear RUSTSEC-2026-0183/0184 (#733)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,15 +925,14 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "libgit2-sys",
  "log",
- "url",
 ]
 
 [[package]]
@@ -1333,9 +1332,9 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.7+1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ ctrlc = "3.4.2"
 dirs = "5.0"
 dunce = "1.0"
 # git2 - base config without TLS (each crate adds platform-specific TLS)
-git2 = { version = "0.20.2", default-features = false, features = [
+git2 = { version = "0.21.0", default-features = false, features = [
   "vendored-libgit2",
 ] }
 glidesort = "0.1"

--- a/crates/fff-core/src/git.rs
+++ b/crates/fff-core/src/git.rs
@@ -62,7 +62,7 @@ impl GitStatusCache {
 
         let mut entries = AHashMap::with_capacity(statuses.len());
         for entry in &statuses {
-            if let Some(entry_path) = entry.path() {
+            if let Ok(entry_path) = entry.path() {
                 // libgit2 returns entry paths with forward slashes on every platform
                 // fff stores native paths - meaning we have forward slash issue on windows
                 let full_path = crate::path_utils::normalize(repo_path.join(entry_path));

--- a/crates/fff-core/tests/fuzz_git_watcher_stress.rs
+++ b/crates/fff-core/tests/fuzz_git_watcher_stress.rs
@@ -773,7 +773,7 @@ fn read_truth_status(base: &Path) -> BTreeMap<String, Status> {
 
     let mut out = BTreeMap::new();
     for entry in statuses.iter() {
-        if let Some(p) = entry.path() {
+        if let Ok(p) = entry.path() {
             // git2 returns forward-slash paths; accept as-is.
             out.insert(p.to_string(), entry.status());
         }
@@ -1258,7 +1258,7 @@ fn get_baseline_status_from_git(base: &Path) -> Vec<Live> {
         Err(_) => return out,
     };
     for entry in statuses.iter() {
-        if let Some(p) = entry.path() {
+        if let Ok(p) = entry.path() {
             let abs = base.join(p);
             // Must be a real file *right now* — ignore stale WT_DELETED rows.
             if abs.is_file() {


### PR DESCRIPTION
Closes #733

## Root cause
Workspace pin `git2 = "0.20.2"` in `Cargo.toml:29` resolves to 0.20.4, which carries two `informational = "unsound"` advisories (RUSTSEC-2026-0183, RUSTSEC-2026-0184). fff does not call the affected APIs (`Remote::list`, `Blame::blame_buffer`) — usage is limited to `Repository`, `StatusOptions`, `Status*`, `Version::get` — but every downstream consumer of `fff-search`/`fff-grep`/`fff-query-parser` sees the advisories in `cargo audit`/`cargo deny` and must add a suppression.

## Fix
Bump workspace `git2` to `0.21.0`. Feature set unchanged (`default-features = false`, `vendored-libgit2`). 0.21 changes `StatusEntry::path()` from `Option<&str>` to `Result<&str, git2::Error>`; adjust the two callers in `crates/fff-core/src/git.rs:65` and `crates/fff-core/tests/fuzz_git_watcher_stress.rs` accordingly (drop non-UTF-8 paths, same behavior as before).

## Steps to reproduce
Confirm the advisories surface on pre-fix `origin/main`:

```sh
cargo install cargo-audit --locked
git fetch origin main && git checkout origin/main
cargo audit --file Cargo.lock
```

Expected: two warnings

```
Crate:     git2
Version:   0.20.4
Warning:   unsound
Title:     Remote::list() passes null pointer to slice::from_raw_parts()
ID:        RUSTSEC-2026-0183

Crate:     git2
Version:   0.20.4
Warning:   unsound
Title:     BlameHunk from Blame::blame_buffer() can build Signatures from null pointers
ID:        RUSTSEC-2026-0184
```

## How verified
```sh
cargo update -p git2
# Updating git2 v0.20.4 -> v0.21.0
# Updating libgit2-sys v0.18.3+1.9.2 -> v0.18.7+1.9.6

cargo check --workspace --tests
# Finished `dev` profile [unoptimized + debuginfo] target(s)

cargo test --workspace
# all suites pass: 124 lib tests + integration suites, 0 failed
```

Diff size: 4 files, +8/-9.

Automated triage via Gustav. Honk-Honk 🪿