### PR TITLE
fix(nvim): refuse fs-root/home index at Lua level before FFI (#745)

### DIFF
--- a/lua/fff/core.lua
+++ b/lua/fff/core.lua
@@ -3,6 +3,9 @@ if not fuzzy then error('Failed to load fff.fuzzy module. Ensure the Rust backen
 
 local M = {}
 
+-- forward declaration; defined with the other utilities at end of file
+local fs_scanning_refusal
+
 ---@class fff.core.State
 local state = {
   ---@type boolean
@@ -111,6 +114,15 @@ M.change_indexing_directory = function(new_path)
 
   local fff_rust = M.ensure_initialized()
   local config = require('fff.conf').get()
+
+  -- Same guard as ensure_initialized: refuse root/home in Lua before the
+  -- FFI reindex, which segfaults on some targets instead of erroring (#745).
+  local refusal = fs_scanning_refusal(vim.tbl_extend('force', config, { base_path = expanded_path }))
+  if refusal then
+    vim.notify('FFF: ' .. refusal, vim.log.levels.WARN)
+    return false
+  end
+
   local ok, err = pcall(fff_rust.restart_index_in_path, expanded_path, {
     follow_symlinks = config.follow_symlinks,
     enable_fs_root_scanning = config.enable_fs_root_scanning,
@@ -128,9 +140,22 @@ end
 
 M.ensure_initialized = function()
   if state.initialized then return fuzzy end
-  state.initialized = true
 
   local config = require('fff.conf').get()
+
+  -- Mirror the Rust refusal (file_picker.rs:862) in Lua. On some
+  -- cross-compiled targets (aarch64 CI builds, see #745) the FFI call
+  -- segfaults instead of returning the error cleanly, and a SIGSEGV can't
+  -- be caught by the pcall around init_file_picker below — it kills the
+  -- whole neovim process. Refuse here before crossing into Rust.
+  local refusal = fs_scanning_refusal(config)
+  if refusal then
+    state.initialized = true
+    vim.notify('FFF: ' .. refusal, vim.log.levels.WARN)
+    return fuzzy
+  end
+
+  state.initialized = true
   if config.logging.enabled then
     local log_success, log_error =
       pcall(fuzzy.init_tracing, config.logging.log_file, config.logging.log_level, config.logging.retain_runs)
@@ -171,6 +196,29 @@ M.ensure_initialized = function()
   })
 
   return fuzzy
+end
+
+--- Returns a refusal message if `config.base_path` is a filesystem root or the
+--- home directory and the matching scan flag is disabled; `nil` otherwise.
+--- @param config table
+--- @return string?
+function fs_scanning_refusal(config)
+  local path = vim.fn.fnamemodify(vim.fn.expand(config.base_path), ':p'):gsub('/+$', '')
+
+  -- Filesystem root: `/` collapses to empty after stripping the trailing
+  -- slash (Windows drive roots like `C:` keep a colon).
+  if not config.enable_fs_root_scanning and (path == '' or path:match('^%a:$')) then
+    return 'Refusing to index filesystem root. Set enable_fs_root_scanning = true to override.'
+  end
+
+  if not config.enable_home_dir_scanning then
+    local home = (vim.fn.expand('$HOME') or ''):gsub('/+$', '')
+    if home ~= '' and path == home then
+      return 'Refusing to index home directory. Set enable_home_dir_scanning = true to override.'
+    end
+  end
+
+  return nil
 end
 
 return M

--- a/lua/fff/core.lua
+++ b/lua/fff/core.lua
@@ -3,7 +3,6 @@ if not fuzzy then error('Failed to load fff.fuzzy module. Ensure the Rust backen
 
 local M = {}
 
--- forward declaration; defined with the other utilities at end of file
 local fs_scanning_refusal
 
 ---@class fff.core.State
@@ -115,8 +114,6 @@ M.change_indexing_directory = function(new_path)
   local fff_rust = M.ensure_initialized()
   local config = require('fff.conf').get()
 
-  -- Same guard as ensure_initialized: refuse root/home in Lua before the
-  -- FFI reindex, which segfaults on some targets instead of erroring (#745).
   local refusal = fs_scanning_refusal(vim.tbl_extend('force', config, { base_path = expanded_path }))
   if refusal then
     vim.notify('FFF: ' .. refusal, vim.log.levels.WARN)
@@ -143,11 +140,8 @@ M.ensure_initialized = function()
 
   local config = require('fff.conf').get()
 
-  -- Mirror the Rust refusal (file_picker.rs:862) in Lua. On some
-  -- cross-compiled targets (aarch64 CI builds, see #745) the FFI call
-  -- segfaults instead of returning the error cleanly, and a SIGSEGV can't
-  -- be caught by the pcall around init_file_picker below — it kills the
-  -- whole neovim process. Refuse here before crossing into Rust.
+  -- Some folks are complaining that neovim instance is closing if ffi returns error on startup (via lazy=false)
+  -- I can't repro so just precheck on lua side to prevent crashing neovim instance
   local refusal = fs_scanning_refusal(config)
   if refusal then
     state.initialized = true
@@ -198,15 +192,9 @@ M.ensure_initialized = function()
   return fuzzy
 end
 
---- Returns a refusal message if `config.base_path` is a filesystem root or the
---- home directory and the matching scan flag is disabled; `nil` otherwise.
---- @param config table
---- @return string?
 function fs_scanning_refusal(config)
   local path = vim.fn.fnamemodify(vim.fn.expand(config.base_path), ':p'):gsub('/+$', '')
 
-  -- Filesystem root: `/` collapses to empty after stripping the trailing
-  -- slash (Windows drive roots like `C:` keep a colon).
   if not config.enable_fs_root_scanning and (path == '' or path:match('^%a:$')) then
     return 'Refusing to index filesystem root. Set enable_fs_root_scanning = true to override.'
   end


### PR DESCRIPTION
Closes #745

## Root cause
Opening nvim at `/` with `lazy=false` kills the entire neovim process on the CI-cross-compiled aarch64 `.so`. The Rust side is *supposed* to return `Error::FilesystemRoot` cleanly (`crates/fff-core/src/file_picker.rs:862`), and a native `cargo build --release` does exactly that. But the published aarch64 binary SIGSEGVs at the `init_file_picker` FFI call instead of returning the error — as the reporter confirmed (`exit=139`, core dump, corrupt stack; native build exits 0).

A SIGSEGV is a hardware signal. The `pcall` around `init_file_picker` (`lua/fff/core.lua`) cannot catch it, so it propagates and takes neovim down. The SIGSEGV banner in the crash buffer comes from fff's own signal handler (`crates/fff-core/src/log.rs:54`).

The underlying aarch64 codegen/segfault is a separate issue for @dmtrKovalenko. This PR is the Lua-level workaround requested in https://github.com/dmtrKovalenko/fff/issues/745#issuecomment-5192924395.

## Fix
Mirror the Rust root/home refusal in Lua and bail *before* crossing the FFI boundary, so the crashing path is never reached:
- `ensure_initialized` refuses when `base_path` is a filesystem root (`/`, `C:`) or `$HOME` with the matching scan flag disabled, notifies at WARN, and returns without calling into Rust.
- `change_indexing_directory` gets the same guard for the `:cd /`-after-init case.
- Honors existing `enable_fs_root_scanning` / `enable_home_dir_scanning` overrides — no new config, no behavior change when scanning is allowed.

~40 LOC, `lua/fff/core.lua` only.

## Steps to reproduce
On pre-fix `main`, published aarch64 build (or any build where the FFI segfaults):
```console
$ cd / && nvim --headless -c "lua require('fff.core').ensure_initialized()" -c "qa!"; echo "exit=$?"

=== CRASH SIGSEGV (fff) ===
=== CRASH END SIGSEGV ===
Segmentation fault (core dumped)
exit=139
```
Expected: clean refusal, neovim survives. Actual: SIGSEGV, exit 139, core dump.

## How verified
Logic of the guard validated in isolation under headless nvim (the module itself needs the compiled backend to load):
```console
$ nvim --headless -l /tmp/test_refusal.lua
root / refused                           got=Refusing to index filesystem root. ...
root / allowed                           got=nil
home refused                             got=Refusing to index home directory. ...
home allowed (default)                   got=nil
normal dir ok                            got=nil
root // refused                          got=Refusing to index filesystem root. ...
ALL PASS
```
`stylua --check lua/fff/core.lua` passes.

Post-fix, `ensure_initialized` at `/` returns without touching the FFI, so neovim no longer crashes regardless of the aarch64 codegen bug.

Automated triage via Gustav. Honk-Honk 🪿