### PR TITLE
fix(pi-fff): make home-dir scanning configurable, warn when indexing $HOME (#743)

### DIFF
--- a/packages/pi-fff/README.md
+++ b/packages/pi-fff/README.md
@@ -134,7 +134,8 @@ Mode precedence:
 - `--fff-mode <mode>` — set mode (see above)
 - `--fff-frecency-db <path>` — path to frecency database (also: `FFF_FRECENCY_DB` env)
 - `--fff-history-db <path>` — path to query history database (also: `FFF_HISTORY_DB` env)
-- `--fff-enable-root-scan` — allow indexing when launched from `/` (also: `FFF_ENABLE_ROOT_SCAN=1` env). FFF refuses to init at the filesystem root by default. Home directory scanning is always enabled for pi.
+- `--fff-enable-root-scan` — allow indexing when launched from `/` (also: `FFF_ENABLE_ROOT_SCAN=1` env). FFF refuses to init at the filesystem root by default.
+- `--fff-enable-home-scan` — index the home directory when launched from `$HOME` (also: `FFF_ENABLE_HOME_SCAN` env). Enabled by default. Disable with `--fff-enable-home-scan=false` or `FFF_ENABLE_HOME_SCAN=0` if your `$HOME` contains huge trees (toolchains, kernel sources, build outputs) that make the background index run for a long time. When launched from `$HOME` with this enabled, pi shows a warning that the whole home tree is being indexed.
 
 ## Data
 

--- a/packages/pi-fff/src/aux-finders.ts
+++ b/packages/pi-fff/src/aux-finders.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import type { FileFinderApi } from "@ff-labs/fff-node";
+import { HOME_DIR } from "./paths";
 import { loadSdk, SCAN_TIMEOUT_MS } from "./sdk";
 
 export const MAX_AUX = 3;
@@ -15,6 +15,9 @@ interface AuxPicker {
 
 export interface AuxOpts {
   enableFsRootScanning: boolean;
+  enableHomeDirScanning?: boolean;
+  // Called before a newly spawned aux picker starts a scan that covers $HOME.
+  onHomeDirScan?: (root: string) => void;
 }
 
 export class AuxFinderPool {
@@ -90,6 +93,13 @@ export class AuxFinderPool {
       this.entries = this.entries.filter((e) => e !== oldest);
     }
 
+    const enableHomeDirScanning = this.opts.enableHomeDirScanning ?? true;
+    // A fresh picker rooted at (or above) $HOME walks the whole home tree, so
+    // the user gets told every time the agent spawns one — see issue #743.
+    if (enableHomeDirScanning && rootCovers(root, HOME_DIR)) {
+      this.opts.onHomeDirScan?.(root);
+    }
+
     const { FileFinder } = await loadSdk();
     // LMDB env can only be opened once per process; the main finder already
     // owns the frecency/history DBs. Aux finders are transient and run without
@@ -97,7 +107,7 @@ export class AuxFinderPool {
     const result = FileFinder.create({
       basePath: root,
       aiMode: true,
-      enableHomeDirScanning: true,
+      enableHomeDirScanning,
       enableFsRootScanning: this.opts.enableFsRootScanning,
     });
     if (!result.ok)
@@ -176,7 +186,7 @@ export function routePathConstraint(
   let candidate = pathConstraint.trim();
   if (!candidate) return null;
   if (candidate === "~" || candidate.startsWith("~/"))
-    candidate = path.join(os.homedir(), candidate.slice(1));
+    candidate = path.join(HOME_DIR, candidate.slice(1));
   if (!path.isAbsolute(candidate)) {
     // Plain workspace-relative constraints stay on the workspace finder.
     if (candidate !== ".." && !candidate.startsWith("../")) return null;

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -22,6 +22,7 @@ import type {
 } from "@ff-labs/fff-node";
 import { Type } from "@sinclair/typebox";
 import { AuxFinderPool, routePathConstraint } from "./aux-finders";
+import { isHomeDir } from "./paths";
 import { buildQuery } from "./query";
 import { loadSdk, SCAN_TIMEOUT_MS } from "./sdk";
 
@@ -35,6 +36,10 @@ const DEFAULT_GREP_LIMIT = 20;
 const DEFAULT_FIND_LIMIT = 30;
 const GREP_MAX_LINE_LENGTH = 500;
 const MENTION_MAX_RESULTS = 20;
+const HOME_SCAN_STATUS_KEY = "fff";
+const HOME_SCAN_POLL_MS = 1_000;
+const HOME_SCAN_DISABLE_HINT =
+  "You can prevent home dir indexing with --fff-enable-home-scan=false (or FFF_ENABLE_HOME_SCAN=0).";
 
 // If we exceed 10 seconds for indexed grep - something is definitely off
 const GREP_TIME_BUDGET_MS = 10_000;
@@ -319,19 +324,31 @@ export default function fffExtension(pi: ExtensionAPI) {
     process.env.FFF_HISTORY_DB ??
     undefined;
 
-  // Root scanning opt-in: flag (boolean) > env ("1"/"true") > false.
-  // FFF refuses to init at / unless this is set. Home dir scanning is on by
-  // default for pi — launching pi from $HOME is a normal flow.
-  function resolveBoolOpt(flagName: string, envName: string): boolean {
+  // flag (boolean) > env ("1"/"true", or "0"/"false") > default.
+  function resolveBoolOpt(
+    flagName: string,
+    envName: string,
+    fallback = false,
+  ): boolean {
     const flag = pi.getFlag(flagName);
     if (typeof flag === "boolean") return flag;
     if (typeof flag === "string") return flag === "true" || flag === "1";
     const env = process.env[envName];
-    return env === "1" || env === "true";
+    if (env === "1" || env === "true") return true;
+    if (env === "0" || env === "false") return false;
+    return fallback;
   }
+  // Root scanning opt-in: FFF refuses to init at / unless this is set.
   const enableFsRootScanning = resolveBoolOpt(
     "fff-enable-root-scan",
     "FFF_ENABLE_ROOT_SCAN",
+  );
+  // Home dir scanning is on by default (launching pi from $HOME is a normal
+  // flow), but configurable so users with huge $HOME trees can opt out.
+  const enableHomeDirScanning = resolveBoolOpt(
+    "fff-enable-home-scan",
+    "FFF_ENABLE_HOME_SCAN",
+    true,
   );
 
   function getMode(): FffMode {
@@ -346,8 +363,27 @@ export default function fffExtension(pi: ExtensionAPI) {
     return currentMode !== "tools-only";
   }
 
+  // Set on session_start; the only handle to the UI outside an event handler.
+  // setStatus is TUI/RPC-only, hence optional.
+  let uiCtx: {
+    ui: {
+      notify: (message: string, type?: "info" | "warning" | "error") => void;
+      setStatus?: (key: string, text: string | undefined) => void;
+    };
+  } | null = null;
+  let homeScanTimer: ReturnType<typeof setInterval> | null = null;
+
+  function warnHomeDirScan(root: string): void {
+    uiCtx?.ui.notify(
+      `(fff): Your cwd (${root}) is too large. Indexing will take additional time and resources.\n${HOME_SCAN_DISABLE_HINT}`,
+      "warning",
+    );
+  }
+
   let auxPool = new AuxFinderPool({
     enableFsRootScanning,
+    enableHomeDirScanning,
+    onHomeDirScan: warnHomeDirScan,
   });
 
   // in case cwd changes we need to figure this out
@@ -370,7 +406,7 @@ export default function fffExtension(pi: ExtensionAPI) {
         frecencyDbPath,
         historyDbPath,
         aiMode: true,
-        enableHomeDirScanning: true,
+        enableHomeDirScanning,
         enableFsRootScanning,
       });
 
@@ -388,7 +424,40 @@ export default function fffExtension(pi: ExtensionAPI) {
     return finderPromise;
   }
 
+  function stopHomeScanStatus(): void {
+    if (homeScanTimer) {
+      clearInterval(homeScanTimer);
+      homeScanTimer = null;
+    }
+    uiCtx?.ui.setStatus?.(HOME_SCAN_STATUS_KEY, undefined);
+  }
+
+  // waitForScan() resolves on timeout too, so the scan can still be running.
+  // Poll the live progress until it settles, then clear the footer.
+  function trackHomeScanStatus(): void {
+    stopHomeScanStatus();
+    if (!uiCtx?.ui.setStatus) return;
+
+    const tick = () => {
+      const progress = mainFinder?.getScanProgress?.();
+      if (!progress?.ok || !progress.value.isScanning) {
+        stopHomeScanStatus();
+        return;
+      }
+      uiCtx?.ui.setStatus?.(
+        HOME_SCAN_STATUS_KEY,
+        `Agent is indexing $HOME (${progress.value.scannedFilesCount} files), this can lead to high CPU`,
+      );
+    };
+
+    homeScanTimer = setInterval(tick, HOME_SCAN_POLL_MS);
+    // Must not hold the process open once pi is done.
+    (homeScanTimer as { unref?: () => void }).unref?.();
+    tick();
+  }
+
   function destroyFinder() {
+    stopHomeScanStatus();
     if (mainFinder && !mainFinder.isDestroyed) {
       mainFinder.destroy();
       mainFinder = null;
@@ -526,9 +595,16 @@ export default function fffExtension(pi: ExtensionAPI) {
     type: "boolean",
   });
 
+  pi.registerFlag("fff-enable-home-scan", {
+    description:
+      "Index the home dir when launched from $HOME (default true; disable with --fff-enable-home-scan=false or FFF_ENABLE_HOME_SCAN=0)",
+    type: "boolean",
+  });
+
   pi.on("session_start", async (_event, ctx) => {
     try {
       activeCwd = ctx.cwd;
+      uiCtx = ctx as unknown as typeof uiCtx;
 
       // Restore persisted mode from session entries. This handles session
       // resume after process restart where env vars are lost, and ensures
@@ -554,7 +630,23 @@ export default function fffExtension(pi: ExtensionAPI) {
       }
 
       registerAutocompleteProvider(ctx);
+
+      // Warn when launched from $HOME with home scanning on: indexing a large
+      // home tree can run for a long time in the background (issue #743).
+      const atHome = enableHomeDirScanning && isHomeDir(activeCwd);
+      if (atHome) {
+        warnHomeDirScan(activeCwd);
+        ctx.ui.setStatus?.(
+          HOME_SCAN_STATUS_KEY,
+          "Agent is indexing $HOME, this can lead to high CPU",
+        );
+      }
+
       await ensureFinder(activeCwd);
+
+      // waitForScan() also resolves on timeout, so poll until the scan really
+      // settles before clearing the footer.
+      if (atHome) trackHomeScanStatus();
     } catch (e: unknown) {
       ctx.ui.notify(
         `FFF init failed: ${e instanceof Error ? e.message : String(e)}`,

--- a/packages/pi-fff/src/paths.ts
+++ b/packages/pi-fff/src/paths.ts
@@ -1,0 +1,9 @@
+import os from "node:os";
+import path from "node:path";
+
+// Resolved once per process: os.homedir() hits the env/passwd on every call.
+export const HOME_DIR = path.resolve(os.homedir());
+
+export function isHomeDir(dir: string): boolean {
+  return path.resolve(dir) === HOME_DIR;
+}

--- a/packages/pi-fff/test/aux-pool.test.ts
+++ b/packages/pi-fff/test/aux-pool.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
+import os from "node:os";
+import path from "node:path";
 
 interface MockFinder {
   isDestroyed: boolean;
@@ -40,10 +42,10 @@ mock.module("@ff-labs/fff-bun", () => finderModule);
 
 const { AuxFinderPool } = await import("../src/aux-finders");
 
-function makePool() {
+function makePool(opts: Record<string, unknown> = {}) {
   created.length = 0;
   createOptions.length = 0;
-  return new AuxFinderPool({ enableFsRootScanning: false });
+  return new AuxFinderPool({ enableFsRootScanning: false, ...opts });
 }
 
 describe("AuxFinderPool covering reuse", () => {
@@ -90,6 +92,31 @@ describe("AuxFinderPool covering reuse", () => {
     const other = await pool.acquire("/a/b");
     expect(other.root).toBe("/a/b");
     expect(created.length).toBe(2);
+  });
+
+  // Regression for #743: the agent spawning an aux picker over $HOME must warn
+  // the user every time, not silently walk the home tree.
+  test("notifies on every aux picker that covers $HOME", async () => {
+    const onHomeDirScan = mock(() => undefined);
+    const pool = makePool({ onHomeDirScan });
+    const home = os.homedir();
+
+    await pool.acquire(home);
+    await pool.acquire(path.dirname(home));
+    expect(onHomeDirScan.mock.calls).toEqual([[home], [path.dirname(home)]]);
+
+    // Project-scoped roots below $HOME do not walk the whole home tree.
+    await pool.acquire(path.join(home, "dev", "some-project"));
+    expect(onHomeDirScan).toHaveBeenCalledTimes(2);
+  });
+
+  test("no aux notification when home scanning is disabled", async () => {
+    const onHomeDirScan = mock(() => undefined);
+    const pool = makePool({ enableHomeDirScanning: false, onHomeDirScan });
+
+    await pool.acquire(os.homedir());
+    expect(onHomeDirScan).not.toHaveBeenCalled();
+    expect(createOptions[0].enableHomeDirScanning).toBe(false);
   });
 
   // Regression for #700: aux finders must not reopen the main frecency/history

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -1,20 +1,35 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import os from "node:os";
 
 type MockFinder = {
   isDestroyed: boolean;
   waitForScan: ReturnType<typeof mock>;
   mixedSearch: ReturnType<typeof mock>;
+  getScanProgress: ReturnType<typeof mock>;
   destroy: ReturnType<typeof mock>;
 };
 
 const createCalls: unknown[] = [];
 let finders: MockFinder[] = [];
 let mixedSearchImpl: ((query: string, options: unknown) => unknown) | undefined;
+let scanProgressImpl: (() => unknown) | undefined;
 
 function createMockFinder(): MockFinder {
   return {
     isDestroyed: false,
     waitForScan: mock(async () => undefined),
+    getScanProgress: mock(() => {
+      if (scanProgressImpl) return scanProgressImpl();
+      return {
+        ok: true,
+        value: {
+          scannedFilesCount: 0,
+          isScanning: false,
+          isWatcherReady: true,
+          isWarmupComplete: true,
+        },
+      };
+    }),
     mixedSearch: mock((query: string, options: unknown) => {
       if (mixedSearchImpl) return mixedSearchImpl(query, options);
       return {
@@ -102,20 +117,21 @@ function createPi(mode?: string) {
   return { pi, events, commands };
 }
 
-function createContext() {
+function createContext(cwd = "/tmp/workspace") {
   return {
-    cwd: "/tmp/workspace",
+    cwd,
     ui: {
       addAutocompleteProvider: mock(() => undefined),
       notify: mock(() => undefined),
       setEditorComponent: mock(() => undefined),
+      setStatus: mock(() => undefined),
     },
   };
 }
 
-async function start(mode?: string) {
+async function start(mode?: string, cwd?: string) {
   const setup = createPi(mode);
-  const ctx = createContext();
+  const ctx = createContext(cwd);
   fffExtension(setup.pi as any);
 
   const sessionStart = setup.events.get("session_start");
@@ -123,6 +139,10 @@ async function start(mode?: string) {
   await sessionStart?.({ reason: "startup" }, ctx);
 
   return { ...setup, ctx };
+}
+
+async function shutdown(setup: { events: Map<string, EventHandler> }) {
+  await setup.events.get("session_shutdown")?.({}, undefined);
 }
 
 function currentProvider(
@@ -143,7 +163,71 @@ beforeEach(() => {
   createCalls.length = 0;
   finders = [];
   mixedSearchImpl = undefined;
+  scanProgressImpl = undefined;
   delete process.env.PI_FFF_MODE;
+  delete process.env.FFF_ENABLE_HOME_SCAN;
+});
+
+// Regression for #743: launching from $HOME must be visible and interruptible.
+describe("pi-fff $HOME scan warning", () => {
+  test("warns and pins a status when cwd is $HOME", async () => {
+    const setup = await start(undefined, os.homedir());
+
+    expect(setup.ctx.ui.notify).toHaveBeenCalledTimes(1);
+    const [message, level] = setup.ctx.ui.notify.mock.calls[0];
+    expect(message).toContain(os.homedir());
+    expect(level).toBe("warning");
+    expect(setup.ctx.ui.setStatus).toHaveBeenCalledWith(
+      "fff",
+      "Agent is indexing $HOME, this can lead to high CPU",
+    );
+    await shutdown(setup);
+  });
+
+  test("stays silent outside $HOME", async () => {
+    const { ctx } = await start();
+
+    expect(ctx.ui.notify).not.toHaveBeenCalled();
+    expect(ctx.ui.setStatus).not.toHaveBeenCalled();
+  });
+
+  test("clears the status once the scan settles", async () => {
+    const setup = await start(undefined, os.homedir());
+
+    expect(setup.ctx.ui.setStatus).toHaveBeenLastCalledWith("fff", undefined);
+    await shutdown(setup);
+  });
+
+  // waitForScan resolves on timeout, so a slow $HOME walk keeps the footer up.
+  test("keeps reporting live progress while the scan is still running", async () => {
+    scanProgressImpl = () => ({
+      ok: true,
+      value: {
+        scannedFilesCount: 12345,
+        isScanning: true,
+        isWatcherReady: false,
+        isWarmupComplete: false,
+      },
+    });
+    const setup = await start(undefined, os.homedir());
+
+    const [key, text] = setup.ctx.ui.setStatus.mock.calls.at(-1) as [string, string];
+    expect(key).toBe("fff");
+    expect(text).toContain("12345 files");
+
+    // session_shutdown must stop the poller and clear the footer.
+    await shutdown(setup);
+    expect(setup.ctx.ui.setStatus).toHaveBeenLastCalledWith("fff", undefined);
+  });
+
+  test("no warning when home scanning is disabled", async () => {
+    process.env.FFF_ENABLE_HOME_SCAN = "0";
+    const setup = await start(undefined, os.homedir());
+
+    expect(setup.ctx.ui.notify).not.toHaveBeenCalled();
+    expect(setup.ctx.ui.setStatus).not.toHaveBeenCalled();
+    await shutdown(setup);
+  });
 });
 
 describe("pi-fff autocomplete registration", () => {
@@ -162,6 +246,14 @@ describe("pi-fff autocomplete registration", () => {
         enableFsRootScanning: false,
       },
     ]);
+  });
+
+  test("FFF_ENABLE_HOME_SCAN=0 disables home dir scanning", async () => {
+    process.env.FFF_ENABLE_HOME_SCAN = "0";
+    await start();
+
+    const opts = createCalls[0] as { enableHomeDirScanning: boolean };
+    expect(opts.enableHomeDirScanning).toBe(false);
   });
 
   test("session_start survives hosts without addAutocompleteProvider", async () => {


### PR DESCRIPTION
Closes #743

## Root cause

`pi-fff` hardcoded `enableHomeDirScanning: true`, overriding the core default guard, so launching pi from `$HOME` always indexed the whole home tree with no opt-out:

- `packages/pi-fff/src/index.ts:370` — main finder
- `packages/pi-fff/src/aux-finders.ts:77` — aux finder pool

Only `fff-enable-root-scan` was configurable. `@XWIlluDelu` traced this to #589, which removed the home flag and forced `true`. The maintainer's advice "do not start pi in `$HOME` if you enable home indexing" was unfollowable — the extension always enabled it.

## Fix

Expose it as `--fff-enable-home-scan` flag + `FFF_ENABLE_HOME_SCAN` env, **default `true`** (behavior unchanged). `resolveBoolOpt` now takes a fallback and accepts `0`/`false` so the default can be turned off. Threaded through both the main finder and `AuxFinderPool`.

On the alerts question: pi exposes `ctx.ui.notify(msg, "info" | "warning" | "error")` and `ctx.ui.setStatus(id, text)` (footer, persists across renders) — docs `extensions.md:2177`, `tui.md:734`. Wired both: a `warning` notify when cwd is `$HOME` with scanning on, plus a footer status. After the 15s `waitForScan` returns, `getScanProgress()` is polled once; if still scanning, the footer keeps showing the live file count instead of clearing, so a long background index over a big home tree is visible.

Note: this only adds the opt-out and visibility. It does not address the other items in the report — no idle-stop, no size/count thresholds, no default excludes, no cross-process index sharing. @dmtrKovalenko those are design changes, out of scope for a triage fix.

## Steps to reproduce

Pre-fix `main`, home scanning cannot be disabled:

```sh
git clone git@github.com:dmtrKovalenko/fff.git && cd fff
git checkout 086044f
grep -n "enableHomeDirScanning" packages/pi-fff/src/index.ts packages/pi-fff/src/aux-finders.ts
# packages/pi-fff/src/index.ts:370:        enableHomeDirScanning: true,
# packages/pi-fff/src/aux-finders.ts:77:      enableHomeDirScanning: true,
```

No flag exists, so launching pi from `$HOME` indexes the whole tree:

```sh
cd $HOME && pi   # full $HOME walk, no way to opt out
```

Behavioral check via the test suite:

```sh
cd packages/pi-fff && bun test test/
```

On pre-fix `main` add this test — it FAILS (`Expected: false, Received: true`):

```ts
test("FFF_ENABLE_HOME_SCAN=0 disables home dir scanning", async () => {
  process.env.FFF_ENABLE_HOME_SCAN = "0";
  await start();
  const opts = createCalls[0] as { enableHomeDirScanning: boolean };
  expect(opts.enableHomeDirScanning).toBe(false);
});
```

Post-fix it passes, and the opt-out works:

```sh
cd $HOME && FFF_ENABLE_HOME_SCAN=0 pi   # native Home guard rejects init, no scan
cd $HOME && pi                          # still scans (default true) + warning shown
```

## How verified

- `bun test test/` in `packages/pi-fff` — **46 pass, 0 fail**.
- Confirmed the new test gates the fix: reverting `enableHomeDirScanning` to hardcoded `true` makes it fail with `Expected: false, Received: true`.
- `bun run lint` and `bun run format:check` produce byte-identical output to `origin/main` (3 warnings, 1 info, 8 format diffs — all pre-existing). No new lint/format regressions.
- `ctx.ui.notify` / `ctx.ui.setStatus` / `getScanProgress` verified against installed `@earendil-works/pi-coding-agent` 0.79.3 docs and `packages/fff-node/src/fff-api.ts:603`. `setStatus` called optionally (`?.`) since it is TUI/RPC-only.
- Zero Rust changes, no hot path touched.

Automated triage via Gustav. Honk-Honk 🪿
