### PR TITLE
fix(pi-fff): dedup concurrent aux finders and bound grep time (#746)

### DIFF
--- a/packages/pi-fff/src/aux-finders.ts
+++ b/packages/pi-fff/src/aux-finders.ts
@@ -19,6 +19,10 @@ export interface AuxOpts {
 
 export class AuxFinderPool {
   private entries: AuxPicker[] = [];
+  // In-flight creations keyed by root. Concurrent acquire() calls for the same
+  // (or a covering) root share one finder/scan instead of each starting a full
+  // duplicate traversal — issue #746. Mirrors the main finder's finderPromise.
+  private pending = new Map<string, Promise<AuxPicker>>();
   constructor(private opts: AuxOpts) {}
 
   destroy(): void {
@@ -27,6 +31,7 @@ export class AuxFinderPool {
     }
 
     this.entries = [];
+    this.pending.clear();
   }
 
   private sweepIdle(now = Date.now()): void {
@@ -58,6 +63,25 @@ export class AuxFinderPool {
       return { finder: covering.finder, root: covering.root };
     }
 
+    // Coalesce concurrent creations for the same root so we scan once. A slow
+    // full-home scan started by one call is awaited by the others instead of
+    // each spawning its own traversal (#746).
+    const inflight = this.pending.get(maybeRoot);
+    if (inflight) {
+      const e = await inflight;
+      e.lastUsed = Date.now();
+      return { finder: e.finder, root: e.root };
+    }
+
+    const creation = this.create(maybeRoot).finally(() => {
+      this.pending.delete(maybeRoot);
+    });
+    this.pending.set(maybeRoot, creation);
+    const entry = await creation;
+    return { finder: entry.finder, root: entry.root };
+  }
+
+  private async create(root: string): Promise<AuxPicker> {
     if (this.entries.length >= MAX_AUX) {
       let oldest = this.entries[0];
       for (const e of this.entries)
@@ -71,19 +95,24 @@ export class AuxFinderPool {
     // owns the frecency/history DBs. Aux finders are transient and run without
     // persistent scoring — see issue #700.
     const result = FileFinder.create({
-      basePath: maybeRoot,
+      basePath: root,
       aiMode: true,
       enableHomeDirScanning: true,
       enableFsRootScanning: this.opts.enableFsRootScanning,
     });
     if (!result.ok)
       throw new Error(
-        `Failed to create aux file finder for ${maybeRoot}: ${result.error}`,
+        `Failed to create aux file finder for ${root}: ${result.error}`,
       );
 
     await result.value.waitForScan(SCAN_TIMEOUT_MS);
-    this.entries.push({ root: maybeRoot, finder: result.value, lastUsed: Date.now() });
-    return { finder: result.value, root: maybeRoot };
+    const entry: AuxPicker = {
+      root,
+      finder: result.value,
+      lastUsed: Date.now(),
+    };
+    this.entries.push(entry);
+    return entry;
   }
 
   size(): number {

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -36,7 +36,7 @@ const DEFAULT_FIND_LIMIT = 30;
 const GREP_MAX_LINE_LENGTH = 500;
 const MENTION_MAX_RESULTS = 20;
 
-// If we exceed 10 seconds for indexed grep - something is definetely off
+// If we exceed 10 seconds for indexed grep - something is definitely off
 const GREP_TIME_BUDGET_MS = 10_000;
 
 type FffMode = "tools-and-ui" | "tools-only" | "override";

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -36,6 +36,13 @@ const DEFAULT_FIND_LIMIT = 30;
 const GREP_MAX_LINE_LENGTH = 500;
 const MENTION_MAX_RESULTS = 20;
 
+// Native grep is synchronous, so an AbortSignal cannot interrupt a search
+// already in flight. Bound wall-clock time instead: over a broad root (e.g.
+// $HOME) an unbounded grep can scan for tens of minutes. 0 would mean
+// unlimited; the engine returns partial results plus a nextCursor on timeout.
+// Issue #746.
+const GREP_TIME_BUDGET_MS = 10_000;
+
 type FffMode = "tools-and-ui" | "tools-only" | "override";
 
 const VALID_MODES: FffMode[] = ["tools-and-ui", "tools-only", "override"];
@@ -713,6 +720,7 @@ export default function fffExtension(pi: ExtensionAPI) {
         beforeContext: params.context ?? 0,
         afterContext: params.context ?? 0,
         classifyDefinitions: true,
+        timeBudgetMs: GREP_TIME_BUDGET_MS,
       });
 
       if (!grepResult.ok) throw new Error(grepResult.error);
@@ -720,8 +728,16 @@ export default function fffExtension(pi: ExtensionAPI) {
       let result = grepResult.value;
       let fuzzyNotice: string | null = null;
 
-      // automatic fuzzy fallback allows to broad the queries and find different cases
-      if (result.items.length === 0 && !params.cursor && mode !== "regex") {
+      // automatic fuzzy fallback allows to broad the queries and find different cases.
+      // Skip it when the exact pass left a nextCursor: it did not exhaust the
+      // corpus (broad root / time budget hit), so a full fuzzy re-traversal would
+      // just repeat the expensive walk. Issue #746.
+      if (
+        result.items.length === 0 &&
+        !result.nextCursor &&
+        !params.cursor &&
+        mode !== "regex"
+      ) {
         // When the caller pinned a specific file (path has an extension), the
         // fuzzy fallback broadens across the whole picker — the file may just
         // be misnamed. For directory constraints (or no path), we keep the
@@ -738,6 +754,7 @@ export default function fffExtension(pi: ExtensionAPI) {
           beforeContext: 0,
           afterContext: 0,
           classifyDefinitions: true,
+          timeBudgetMs: GREP_TIME_BUDGET_MS,
         });
 
         if (fuzzy.ok && fuzzy.value.items.length > 0) {

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -36,11 +36,7 @@ const DEFAULT_FIND_LIMIT = 30;
 const GREP_MAX_LINE_LENGTH = 500;
 const MENTION_MAX_RESULTS = 20;
 
-// Native grep is synchronous, so an AbortSignal cannot interrupt a search
-// already in flight. Bound wall-clock time instead: over a broad root (e.g.
-// $HOME) an unbounded grep can scan for tens of minutes. 0 would mean
-// unlimited; the engine returns partial results plus a nextCursor on timeout.
-// Issue #746.
+// If we exceed 10 seconds for indexed grep - something is definetely off
 const GREP_TIME_BUDGET_MS = 10_000;
 
 type FffMode = "tools-and-ui" | "tools-only" | "override";
@@ -728,10 +724,8 @@ export default function fffExtension(pi: ExtensionAPI) {
       let result = grepResult.value;
       let fuzzyNotice: string | null = null;
 
-      // automatic fuzzy fallback allows to broad the queries and find different cases.
-      // Skip it when the exact pass left a nextCursor: it did not exhaust the
-      // corpus (broad root / time budget hit), so a full fuzzy re-traversal would
-      // just repeat the expensive walk. Issue #746.
+      // if we hit the timeout do not run the fuzzy fallback
+      // cause it will only consumer more time 
       if (
         result.items.length === 0 &&
         !result.nextCursor &&

--- a/packages/pi-fff/test/aux-dedup.test.ts
+++ b/packages/pi-fff/test/aux-dedup.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, mock, test } from "bun:test";
+
+interface MockFinder {
+  isDestroyed: boolean;
+  basePath: string;
+  waitForScan: (ms: number) => Promise<void>;
+  destroy: () => void;
+}
+
+const created: MockFinder[] = [];
+
+function createMockFinder(basePath: string): MockFinder {
+  const finder: MockFinder = {
+    isDestroyed: false,
+    basePath,
+    // simulate a slow scan so concurrent acquires overlap
+    waitForScan: () => new Promise((r) => setTimeout(r, 50)),
+    destroy: () => {
+      finder.isDestroyed = true;
+    },
+  };
+  created.push(finder);
+  return finder;
+}
+
+const finderModule = {
+  FileFinder: {
+    create: (options: Record<string, unknown>) => ({
+      ok: true,
+      value: createMockFinder(options.basePath as string),
+    }),
+  },
+};
+
+mock.module("@ff-labs/fff-node", () => finderModule);
+mock.module("@ff-labs/fff-bun", () => finderModule);
+
+const { AuxFinderPool } = await import("../src/aux-finders");
+
+describe("AuxFinderPool concurrent dedup (#746)", () => {
+  test("two concurrent acquires for same root share one finder", async () => {
+    created.length = 0;
+    const pool = new AuxFinderPool({ enableFsRootScanning: false });
+    const [a, b] = await Promise.all([
+      pool.acquire("/Users/x"),
+      pool.acquire("/Users/x"),
+    ]);
+    expect(created.length).toBe(1);
+    expect(a.finder).toBe(b.finder);
+  });
+
+  test("sequential acquire after in-flight one resolves still reuses", async () => {
+    created.length = 0;
+    const pool = new AuxFinderPool({ enableFsRootScanning: false });
+    const first = pool.acquire("/Users/x");
+    const second = pool.acquire("/Users/x");
+    await Promise.all([first, second]);
+    const third = await pool.acquire("/Users/x");
+    expect(created.length).toBe(1);
+    expect(third.root).toBe("/Users/x");
+  });
+});


### PR DESCRIPTION
Closes #746

## Root cause
`AuxFinderPool.acquire()` pushes into `entries` only after `waitForScan()` resolves (`packages/pi-fff/src/aux-finders.ts:84`), so two concurrent `acquire("/Users/<user>")` both observe empty `entries` and each spawn a separate full-home scan — no dedup, unlike the main finder's `finderPromise`. Separately, `picker.grep()` (`packages/pi-fff/src/index.ts:708`) was called with no `timeBudgetMs`; the native call is synchronous so an `AbortSignal` cannot interrupt an in-flight search, and the fuzzy fallback repeated the full traversal after an exhausted exact pass.

## Fix
Coalesce in-flight `AuxFinderPool` creations by root through a `pending` map so concurrent acquires share one finder/scan. Pass a finite `GREP_TIME_BUDGET_MS` (10s) to both native grep calls (engine returns partial results + `nextCursor` on timeout). Skip the automatic fuzzy fallback when the exact pass left a `nextCursor` (corpus not exhausted), avoiding a repeated broad-root walk.

## Steps to reproduce
On pre-fix `origin/main`:

```sh
cd packages/pi-fff
cat > test/repro.test.ts <<'TS'
import { describe, expect, mock, test } from "bun:test";
const created: any[] = [];
const mod = { FileFinder: { create: (o: any) => {
  const f = { isDestroyed: false, basePath: o.basePath,
    waitForScan: () => new Promise((r) => setTimeout(r, 50)),
    destroy() { f.isDestroyed = true; } };
  created.push(f); return { ok: true, value: f };
} } };
mock.module("@ff-labs/fff-node", () => mod);
mock.module("@ff-labs/fff-bun", () => mod);
const { AuxFinderPool } = await import("../src/aux-finders");
describe("#746", () => { test("dedup", async () => {
  const pool = new AuxFinderPool({ enableFsRootScanning: false });
  const [a, b] = await Promise.all([pool.acquire("/Users/x"), pool.acquire("/Users/x")]);
  expect(created.length).toBe(1);
  expect(a.finder).toBe(b.finder);
}); });
TS
bun test test/repro.test.ts
```

Expected: `created.length === 1`, one shared finder.
Actual (pre-fix):

```
Expected: 1
Received: 2
(fail) #746 > dedup
```

Two separate finders created for the same root → two concurrent full-home scans, matching the reported tens-of-minutes hang.

## How verified
```sh
cd packages/pi-fff && bun test test/
# 47 pass, 0 fail (includes new test/aux-dedup.test.ts covering the race)
```
The regression test `two concurrent acquires for same root share one finder` fails on pre-fix `main` and passes with this change.

Automated triage via Gustav. Honk-Honk 🪿