### PR TITLE
fix(pi-fff): cache sdk import across reloads to avoid /reload hang

### DIFF
--- a/packages/pi-fff/src/sdk.ts
+++ b/packages/pi-fff/src/sdk.ts
@@ -22,8 +22,21 @@ function detectRuntime(): "bun" | "node" {
 export function loadSdk(): Promise<{ FileFinder: FileFinderStatic }> {
   if (sdkPromise) return sdkPromise;
 
+  // Pi reloads extension modules with jiti moduleCache:false, so this module
+  // is re-executed on every /reload. Re-importing the fff-bun module graph
+  // (which top-level awaits a `type: "file"` import of the native .so) hangs
+  // forever inside the Bun-compiled pi binary. Cache the first import on
+  // globalThis so reloads reuse the resolved module instead of re-importing.
+  const g = globalThis as Record<string, unknown>;
+  if (g.__fffSdkPromiseGlobal) {
+    sdkPromise = g.__fffSdkPromiseGlobal as Promise<{ FileFinder: FileFinderStatic }>;
+    return sdkPromise;
+  }
+
   // default to node as it seems like default option
   const pkg = detectRuntime() === "bun" ? "@ff-labs/fff-bun" : "@ff-labs/fff-node";
-  sdkPromise = import(pkg) as Promise<{ FileFinder: FileFinderStatic }>;
-  return sdkPromise;
+  const p = import(pkg) as Promise<{ FileFinder: FileFinderStatic }>;
+  sdkPromise = p;
+  (globalThis as Record<string, unknown>).__fffSdkPromiseGlobal = p;
+  return p;
 }


### PR DESCRIPTION
Closes #757

## Root cause

Pi reloads extension modules with `jiti` `moduleCache: false`, so `loadSdk()` in `packages/pi-fff/src/sdk.ts` re-executes a **dynamic `import("@ff-labs/fff-bun")` on every `/reload`**. The fff-bun module graph top-level awaits a `type: "file"` import of the native `libfff_c.so` (`packages/fff-bun/src/embedded.ts`), which **never resolves when re-imported inside the Bun-compiled pi binary**. Since pi awaits all `session_start` handlers without a timeout, the reload screen sticks on "Reloading keybindings..." forever (CPU ≈ 0).

The first import at startup resolves fine (~20ms); plain `bun` re-imports also work — the hang is specific to the pi Bun binary + jiti combination.

## Fix

Cache the first import on `globalThis` so reloads reuse the resolved module instead of re-importing:

```ts
const g = globalThis as Record<string, unknown>;
if (g.__fffSdkPromiseGlobal) {
  sdkPromise = g.__fffSdkPromiseGlobal as Promise<{ FileFinder: FileFinderStatic }>;
  return sdkPromise;
}
...
sdkPromise = p;
(globalThis as Record<string, unknown>).__fffSdkPromiseGlobal = p;
```

## Verification

Reproduced in an isolated env (copied agent dir + `PI_CODING_AGENT_DIR`, PTY driver):
- Before: `/reload` stuck >60s, no "Reloaded keybindings" line, process at ~0% CPU.
- After: **3 consecutive `/reload` calls all succeed in ~2s** with the full 28-package user settings.

Note: #599 (non-blocking session_start warmup) would mask the UI hang, but the background import would still hang and break subsequent fff tool calls, which `await` the same in-flight `sdkPromise`. This import-level fix is complementary.
