### PR TITLE
feat(fff.nvim): opt-in ordered fuzzy-part matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,7 @@ require('fff').setup({
   },
   file_picker = {
     fuzzy_query_highlighting = false, -- true to highlight fuzzy query matches in file picker results
+    ordered_fuzzy_parts = false, -- true to require space-separated query parts ("foo bar") to match in typed order
   },
   select = {
     -- Return winid to open the chosen file in, or nil to open in the original window

--- a/crates/fff-core/src/file_picker.rs
+++ b/crates/fff-core/src/file_picker.rs
@@ -1034,12 +1034,36 @@ impl FilePicker {
     /// The query should be parsed using [`crate::FFFQuery`] before calling
     /// this function. If a [`crate::QueryTracker`] is provided, the search will
     /// automatically look up the last selected file for this query and boost it
-    #[tracing::instrument(skip_all, name = "Fuzzy file search", fields(query = query.raw_query))]
     pub fn fuzzy_search<'q>(
         &self,
         query: &'q FFFQuery<'q>,
         query_tracker: Option<&QueryTracker>,
         options: FuzzySearchOptions<'q>,
+    ) -> SearchResult<'_> {
+        self.fuzzy_search_impl(query, query_tracker, options, false)
+    }
+
+    /// Same as [`FilePicker::fuzzy_search`], but opts into ordered fuzzy-part
+    /// matching: a multi-word query must match as one in-order subsequence
+    /// instead of each space-separated part matching independently anywhere
+    /// in the candidate.
+    pub fn fuzzy_search_ordered<'q>(
+        &self,
+        query: &'q FFFQuery<'q>,
+        query_tracker: Option<&QueryTracker>,
+        options: FuzzySearchOptions<'q>,
+        ordered_fuzzy_parts: bool,
+    ) -> SearchResult<'_> {
+        self.fuzzy_search_impl(query, query_tracker, options, ordered_fuzzy_parts)
+    }
+
+    #[tracing::instrument(skip_all, name = "Fuzzy file search", fields(query = query.raw_query))]
+    fn fuzzy_search_impl<'q>(
+        &self,
+        query: &'q FFFQuery<'q>,
+        query_tracker: Option<&QueryTracker>,
+        options: FuzzySearchOptions<'q>,
+        ordered_fuzzy_parts: bool,
     ) -> SearchResult<'_> {
         let files = self.get_files();
         let max_threads = if options.max_threads == 0 {
@@ -1108,9 +1132,16 @@ impl FilePicker {
             self.sync_data.base_count,
             base_arena,
             overflow_arena,
+            ordered_fuzzy_parts,
         );
-        let match_byte_offsets =
-            fuzzy_match_byte_offsets_for_page(query, &items, max_typos, base_arena, overflow_arena);
+        let match_byte_offsets = fuzzy_match_byte_offsets_for_page(
+            query,
+            &items,
+            max_typos,
+            base_arena,
+            overflow_arena,
+            ordered_fuzzy_parts,
+        );
 
         info!(
             ?query,
@@ -1138,6 +1169,26 @@ impl FilePicker {
         &self,
         query: &'q FFFQuery<'q>,
         options: FuzzySearchOptions<'q>,
+    ) -> DirSearchResult<'_> {
+        self.fuzzy_search_directories_impl(query, options, false)
+    }
+
+    /// Same as [`FilePicker::fuzzy_search_directories`], but opts into
+    /// ordered fuzzy-part matching (see [`FilePicker::fuzzy_search_ordered`]).
+    pub fn fuzzy_search_directories_ordered<'q>(
+        &self,
+        query: &'q FFFQuery<'q>,
+        options: FuzzySearchOptions<'q>,
+        ordered_fuzzy_parts: bool,
+    ) -> DirSearchResult<'_> {
+        self.fuzzy_search_directories_impl(query, options, ordered_fuzzy_parts)
+    }
+
+    fn fuzzy_search_directories_impl<'q>(
+        &self,
+        query: &'q FFFQuery<'q>,
+        options: FuzzySearchOptions<'q>,
+        ordered_fuzzy_parts: bool,
     ) -> DirSearchResult<'_> {
         let dirs = self.get_dirs();
         let max_threads = if options.max_threads == 0 {
@@ -1174,8 +1225,13 @@ impl FilePicker {
         let overflow_arena = self.sync_data.arena_overflow_ptr();
         let time = std::time::Instant::now();
 
-        let (items, scores, total_matched) =
-            crate::score::fuzzy_match_and_score_dirs(dirs, &context, arena, overflow_arena);
+        let (items, scores, total_matched) = crate::score::fuzzy_match_and_score_dirs(
+            dirs,
+            &context,
+            arena,
+            overflow_arena,
+            ordered_fuzzy_parts,
+        );
 
         info!(
             ?query,
@@ -1208,6 +1264,28 @@ impl FilePicker {
         query_tracker: Option<&QueryTracker>,
         options: FuzzySearchOptions<'q>,
     ) -> MixedSearchResult<'_> {
+        self.fuzzy_search_mixed_impl(query, query_tracker, options, false)
+    }
+
+    /// Same as [`FilePicker::fuzzy_search_mixed`], but opts into ordered
+    /// fuzzy-part matching (see [`FilePicker::fuzzy_search_ordered`]).
+    pub fn fuzzy_search_mixed_ordered<'q>(
+        &self,
+        query: &'q FFFQuery<'q>,
+        query_tracker: Option<&QueryTracker>,
+        options: FuzzySearchOptions<'q>,
+        ordered_fuzzy_parts: bool,
+    ) -> MixedSearchResult<'_> {
+        self.fuzzy_search_mixed_impl(query, query_tracker, options, ordered_fuzzy_parts)
+    }
+
+    fn fuzzy_search_mixed_impl<'q>(
+        &self,
+        query: &'q FFFQuery<'q>,
+        query_tracker: Option<&QueryTracker>,
+        options: FuzzySearchOptions<'q>,
+        ordered_fuzzy_parts: bool,
+    ) -> MixedSearchResult<'_> {
         let location = query.location;
         let page_offset = options.pagination.offset;
         let page_limit = if options.pagination.limit > 0 {
@@ -1229,7 +1307,7 @@ impl FilePicker {
             },
             ..options
         };
-        let dir_results = self.fuzzy_search_directories(query, dir_options);
+        let dir_results = self.fuzzy_search_directories_impl(query, dir_options, ordered_fuzzy_parts);
 
         if dirs_only {
             let total_matched = dir_results.total_matched;
@@ -1273,7 +1351,7 @@ impl FilePicker {
             },
             ..options
         };
-        let file_results = self.fuzzy_search(query, query_tracker, file_options);
+        let file_results = self.fuzzy_search_impl(query, query_tracker, file_options, ordered_fuzzy_parts);
 
         // Merge by score descending.
         let total_matched = file_results.total_matched + dir_results.total_matched;

--- a/crates/fff-core/src/grep/grep_tests.rs
+++ b/crates/fff-core/src/grep/grep_tests.rs
@@ -97,6 +97,38 @@ fn test_fuzzy_typo_scoring() {
 }
 
 #[test]
+fn test_fuzzy_grep_multi_word_already_order_sensitive() {
+    // Fuzzy grep joins all fuzzy parts into one needle (`FFFQuery::grep_text`)
+    // and runs a single frizbee match, so a multi-word query already only
+    // matches lines where the words appear in typed order — independent of
+    // the file-picker's opt-in `ordered_fuzzy_parts` setting, which only
+    // changes `crates/fff-core/src/score.rs`'s per-part AND matcher. This
+    // locks down that invariant: grep's fuzzy mode needs no code change to
+    // satisfy "ordered parts", on or off.
+    let query = fff_query_parser::FFFQuery::parse("handler auth", fff_query_parser::GrepConfig);
+    let needle = query.grep_text();
+    assert_eq!(needle, "handler auth");
+
+    let config = neo_frizbee::Config {
+        max_typos: Some(0),
+        sort: false,
+        ..Default::default()
+    };
+
+    let in_order_line = "fn handler() { auth(); }";
+    let reversed_line = "fn auth() { handler(); }";
+
+    assert!(
+        !neo_frizbee::match_list_indices(&needle, &[in_order_line], &config).is_empty(),
+        "in-order line should match"
+    );
+    assert!(
+        neo_frizbee::match_list_indices(&needle, &[reversed_line], &config).is_empty(),
+        "reversed line must NOT match — grep fuzzy mode is already order-sensitive"
+    );
+}
+
+#[test]
 fn test_multi_grep_search() {
     use crate::file_picker::{FilePicker, FilePickerOptions};
     use std::io::Write;

--- a/crates/fff-core/src/score.rs
+++ b/crates/fff-core/src/score.rs
@@ -42,6 +42,26 @@ fn resolve_file_chunks(
     Some((ptrs.len(), file.path.byte_len))
 }
 
+/// Join already-length-filtered fuzzy parts into a single ordered-match
+/// needle, when there's more than one meaningful part. Concatenates without
+/// a separator: candidate paths rarely contain a literal join character
+/// (unlike grep, which matches free-form text where a literal space is
+/// common), and spending typo budget on a synthetic separator would weaken
+/// real typo tolerance for the parts themselves. Returns `None` when
+/// there's nothing to join (0 or 1 valid parts), so callers fall back to
+/// their normal single/empty-part handling — the exact same handling
+/// unordered mode already uses for these cases.
+///
+/// Callers must pass parts already filtered the same way `match_fuzzy_parts`
+/// filters `valid_parts` (`len() >= 2`), so the needle used for scoring and
+/// the needle used for highlight recomputation are always identical.
+fn join_ordered_parts(valid_parts: &[&str]) -> Option<String> {
+    if valid_parts.len() < 2 {
+        return None;
+    }
+    Some(valid_parts.concat())
+}
+
 #[inline]
 fn match_fuzzy_parts(
     fuzzy_parts: &[&str],
@@ -145,6 +165,7 @@ pub(crate) fn fuzzy_match_and_score_files<'a>(
     base_count: usize,
     base_arena: ArenaPtr,
     overflow_arena: ArenaPtr,
+    ordered_fuzzy_parts: bool,
 ) -> (Vec<&'a FileItem>, Vec<Score>, usize) {
     // Process overflow files first: newly added files (created after the
     // initial scan) live in the overflow arena and are more likely to be
@@ -153,17 +174,23 @@ pub(crate) fn fuzzy_match_and_score_files<'a>(
     // putting them first in the list makes sorting more efficient and gives
     // them tiebreaker advantage in case sorting is the same
     let results = if files.len() > base_count {
-        let mut results = match_and_score_in_arena(&files[base_count..], context, overflow_arena);
+        let mut results = match_and_score_in_arena(
+            &files[base_count..],
+            context,
+            overflow_arena,
+            ordered_fuzzy_parts,
+        );
 
         results.extend(match_and_score_in_arena(
             &files[..base_count],
             context,
             base_arena,
+            ordered_fuzzy_parts,
         ));
 
         results
     } else {
-        match_and_score_in_arena(files, context, base_arena)
+        match_and_score_in_arena(files, context, base_arena, ordered_fuzzy_parts)
     };
 
     sort_and_paginate(results, context)
@@ -175,11 +202,30 @@ pub(crate) fn fuzzy_match_byte_offsets_for_page<'q>(
     max_typos: u16,
     base_arena: ArenaPtr,
     overflow_arena: ArenaPtr,
+    ordered: bool,
 ) -> Vec<SmallVec<[(u32, u32); 4]>> {
-    let parts: Vec<&str> = match &query.fuzzy_query {
+    // Same length filter `match_fuzzy_parts` applies as `valid_parts`, so
+    // this and the scoring pass agree on which parts are "real" vs noise.
+    let valid_parts: Vec<&str> = match &query.fuzzy_query {
         FuzzyQuery::Text(text) if text.len() >= 2 => vec![*text],
         FuzzyQuery::Parts(parts) => parts.iter().copied().filter(|p| p.len() >= 2).collect(),
         _ => Vec::new(),
+    };
+
+    // Mirror the scoring pass: highlight the same single joined-needle match
+    // (via the shared `join_ordered_parts` helper) so ranges stay consistent
+    // with an ordered-mode score.
+    let joined_query;
+    let parts: Vec<&str> = if ordered {
+        match join_ordered_parts(&valid_parts) {
+            Some(joined) => {
+                joined_query = joined;
+                vec![joined_query.as_str()]
+            }
+            None => valid_parts,
+        }
+    } else {
+        valid_parts
     };
 
     let mut ranges_by_item = vec![SmallVec::new(); items.len()];
@@ -398,6 +444,7 @@ pub(crate) fn fuzzy_match_and_score_dirs<'a>(
     context: &ScoringContext,
     arena: ArenaPtr,
     overflow_arena: ArenaPtr,
+    ordered_fuzzy_parts: bool,
 ) -> (Vec<&'a DirItem>, Vec<Score>, usize) {
     if dirs.is_empty() {
         return (vec![], vec![], 0);
@@ -417,12 +464,32 @@ pub(crate) fn fuzzy_match_and_score_dirs<'a>(
         }
     };
 
-    let fuzzy_parts: &[&str] = match &parsed_query.fuzzy_query {
+    let raw_fuzzy_parts: &[&str] = match &parsed_query.fuzzy_query {
         FuzzyQuery::Text(t) if t.len() >= 2 => std::slice::from_ref(t),
         FuzzyQuery::Parts(parts) if !parts.is_empty() => parts.as_slice(),
         _ => {
             return score_dirs_by_frecency(&working_dirs, context);
         }
+    };
+
+    let joined_query;
+    let joined_query_ref: &str;
+    let fuzzy_parts: &[&str] = if ordered_fuzzy_parts {
+        let valid_for_join: Vec<&str> = raw_fuzzy_parts
+            .iter()
+            .copied()
+            .filter(|p| p.len() >= 2)
+            .collect();
+        match join_ordered_parts(&valid_for_join) {
+            Some(joined) => {
+                joined_query = joined;
+                joined_query_ref = joined_query.as_str();
+                std::slice::from_ref(&joined_query_ref)
+            }
+            None => raw_fuzzy_parts,
+        }
+    } else {
+        raw_fuzzy_parts
     };
 
     let valid_parts: Vec<&str> = fuzzy_parts
@@ -606,6 +673,7 @@ fn match_and_score_in_arena<'a>(
     files: &'a [FileItem],
     context: &ScoringContext,
     arena: ArenaPtr,
+    ordered_fuzzy_parts: bool,
 ) -> Vec<(&'a FileItem, Score)> {
     if files.is_empty() {
         return vec![];
@@ -624,7 +692,7 @@ fn match_and_score_in_arena<'a>(
         }
     };
 
-    let fuzzy_parts: &[&str] = match &parsed.fuzzy_query {
+    let raw_fuzzy_parts: &[&str] = match &parsed.fuzzy_query {
         FuzzyQuery::Text(t) if t.len() >= 2 => std::slice::from_ref(t),
         FuzzyQuery::Parts(parts) if !parts.is_empty() => parts.as_slice(),
         _ => {
@@ -632,7 +700,34 @@ fn match_and_score_in_arena<'a>(
         }
     };
 
-    debug_assert!(!fuzzy_parts.is_empty());
+    debug_assert!(!raw_fuzzy_parts.is_empty());
+
+    // Ordered mode: join length-filtered parts into one needle and reuse the
+    // existing single-needle match path (same as a single-token query) so
+    // multi-word queries require their parts as one in-order fuzzy
+    // subsequence. Filtering before joining (rather than after) keeps this
+    // needle identical to the one `fuzzy_match_byte_offsets_for_page` builds
+    // for highlights, via the shared `join_ordered_parts` helper.
+    let joined_query;
+    let joined_query_ref: &str;
+    let fuzzy_parts: &[&str] = if ordered_fuzzy_parts {
+        let valid_for_join: Vec<&str> = raw_fuzzy_parts
+            .iter()
+            .copied()
+            .filter(|p| p.len() >= 2)
+            .collect();
+        match join_ordered_parts(&valid_for_join) {
+            Some(joined) => {
+                joined_query = joined;
+                joined_query_ref = joined_query.as_str();
+                std::slice::from_ref(&joined_query_ref)
+            }
+            None => raw_fuzzy_parts,
+        }
+    } else {
+        raw_fuzzy_parts
+    };
+
     let has_uppercase = fuzzy_parts
         .iter()
         .any(|p| p.chars().any(|c| c.is_uppercase()));
@@ -1330,12 +1425,212 @@ mod filename_bonus_tests {
             },
         };
         let (items, scores, _) =
-            fuzzy_match_and_score_files(files, &ctx, files.len(), arena, arena);
+            fuzzy_match_and_score_files(files, &ctx, files.len(), arena, arena, false);
         items
             .iter()
             .zip(scores.iter())
             .map(|(f, s)| (f.relative_path(arena).to_string(), s.clone()))
             .collect()
+    }
+
+    /// Like `search`, but with `ordered_fuzzy_parts` enabled.
+    fn search_ordered(files: &[FileItem], query: &str, arena: ArenaPtr) -> Vec<(String, Score)> {
+        let parser = QueryParser::default();
+        let parsed = parser.parse(query);
+
+        let effective_query = match &parsed.fuzzy_query {
+            FuzzyQuery::Text(t) => *t,
+            FuzzyQuery::Parts(parts) if !parts.is_empty() => parts[0],
+            _ => query,
+        };
+        let max_typos = (effective_query.len() as u16 / 4).clamp(2, 6);
+
+        let ctx = ScoringContext {
+            query: &parsed,
+            max_threads: 1,
+            max_typos,
+            current_file: None,
+            last_same_query_match: None,
+            project_path: None,
+            combo_boost_score_multiplier: 100,
+            min_combo_count: 3,
+
+            pagination: PaginationArgs {
+                offset: 0,
+                limit: 100,
+            },
+        };
+        let (items, scores, _) =
+            fuzzy_match_and_score_files(files, &ctx, files.len(), arena, arena, true);
+        items
+            .iter()
+            .zip(scores.iter())
+            .map(|(f, s)| (f.relative_path(arena).to_string(), s.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn test_ordered_fuzzy_parts_off_matches_parts_unordered() {
+        // Default (off) behavior: each part is an independent AND filter,
+        // so both paths match regardless of which part appears first.
+        let (files, arena) = make_files(&["src/handler/auth.rs", "auth/src/handler.rs"]);
+
+        let results = search(&files, "handler auth", arena);
+
+        assert_eq!(
+            results.len(),
+            2,
+            "unordered mode should match both files, got {results:?}"
+        );
+    }
+
+    #[test]
+    fn test_ordered_fuzzy_parts_on_requires_typed_order() {
+        // Ordered mode: "handler auth" must appear as one in-order
+        // subsequence. "src/handler/auth.rs" has handler before auth (matches);
+        // "auth/src/handler.rs" has auth before handler (must NOT match).
+        let (files, arena) = make_files(&["src/handler/auth.rs", "auth/src/handler.rs"]);
+
+        let results = search_ordered(&files, "handler auth", arena);
+
+        assert_eq!(
+            results.len(),
+            1,
+            "ordered mode should only match the in-order path, got {results:?}"
+        );
+        assert_eq!(results[0].0, "src/handler/auth.rs");
+    }
+
+    #[test]
+    fn test_ordered_fuzzy_parts_no_literal_space_required_in_candidate() {
+        // Regression: the joined ordered-mode needle must NOT require a
+        // literal space character in the candidate. Candidate paths spell
+        // each word's letters with separators between them but never
+        // contain a space — "alp bet" joined WITH a space (`"alp bet"`)
+        // would burn typo budget on a needle character ('  ') that can
+        // never match a path, weakening real typo tolerance. Joining
+        // without a separator (`"alpbet"`) has no such cost.
+        let (files, arena) = make_files(&[
+            "a_l_p_xx_b_e_t.rs",  // "alp" then "bet", in typed order
+            "b_e_t_xx_a_l_p.rs",  // "bet" then "alp", reversed
+        ]);
+
+        let results = search_ordered(&files, "alp bet", arena);
+
+        assert_eq!(
+            results.len(),
+            1,
+            "ordered mode should only match the in-order candidate, got {results:?}"
+        );
+        assert_eq!(results[0].0, "a_l_p_xx_b_e_t.rs");
+    }
+
+    #[test]
+    fn test_ordered_fuzzy_parts_many_short_parts_still_match() {
+        // Empirically motivates joining without a separator: a space-joined
+        // needle for this query ("ab cd ef gh" -> 11 chars incl. 3 literal
+        // spaces) burns 3 of its 2-typo budget on spaces that can never
+        // match a path, and the match is dropped entirely. Joining without
+        // a separator ("abcdefgh") spends 0 budget on synthetic characters
+        // and matches cleanly.
+        let (files, arena) = make_files(&["ab_cd_ef_gh.rs"]);
+        let results = search_ordered(&files, "ab cd ef gh", arena);
+        assert!(
+            !results.is_empty(),
+            "expected a match for a clean in-order candidate, got none"
+        );
+        assert_eq!(results[0].0, "ab_cd_ef_gh.rs");
+    }
+
+    #[test]
+    fn test_ordered_fuzzy_parts_repeated_whitespace_ignored() {
+        let (files, arena) = make_files(&["src/handler/auth.rs", "auth/src/handler.rs"]);
+
+        let collapsed = search_ordered(&files, "handler auth", arena);
+        let spaced = search_ordered(&files, "handler   auth", arena);
+
+        assert_eq!(
+            collapsed.iter().map(|(p, _)| p.clone()).collect::<Vec<_>>(),
+            spaced.iter().map(|(p, _)| p.clone()).collect::<Vec<_>>(),
+            "repeated whitespace between parts must not change ordered matching"
+        );
+    }
+
+    #[test]
+    fn test_ordered_fuzzy_parts_combines_with_constraints() {
+        // Extension constraint still filters candidates before fuzzy
+        // matching runs, independent of ordered mode.
+        let (files, arena) = make_files(&[
+            "src/handler/auth.rs",
+            "src/handler/auth.lua",
+            "auth/src/handler.rs",
+        ]);
+
+        let results = search_ordered(&files, "*.rs handler auth", arena);
+
+        assert_eq!(
+            results.len(),
+            1,
+            "extension constraint + ordered fuzzy should leave one match, got {results:?}"
+        );
+        assert_eq!(results[0].0, "src/handler/auth.rs");
+    }
+
+    #[test]
+    fn test_ordered_fuzzy_parts_smart_case_bonus_preserved() {
+        // Matching case should still score higher than mismatched case under
+        // ordered mode, same as the unordered smart-case bonus.
+        let (files, arena) = make_files(&["src/AuthHandler.rs", "src/authhandler_other.rs"]);
+
+        let results = search_ordered(&files, "Auth Handler", arena);
+
+        assert!(
+            results.len() >= 2,
+            "both files should fuzzy match, got {results:?}"
+        );
+        assert_eq!(
+            results[0].0, "src/AuthHandler.rs",
+            "matching-case candidate should rank first under ordered mode"
+        );
+    }
+
+    #[test]
+    fn test_ordered_fuzzy_parts_pagination_and_highlights_agree() {
+        let (files, arena) = make_files(&["src/handler/auth.rs", "auth/src/handler.rs"]);
+
+        let parser = QueryParser::default();
+        let parsed = parser.parse("handler auth");
+        let ctx = ScoringContext {
+            query: &parsed,
+            max_threads: 1,
+            max_typos: 2,
+            current_file: None,
+            last_same_query_match: None,
+            project_path: None,
+            combo_boost_score_multiplier: 100,
+            min_combo_count: 3,
+            pagination: PaginationArgs {
+                offset: 0,
+                limit: 100,
+            },
+        };
+
+        let (items, _scores, total_matched) =
+            fuzzy_match_and_score_files(&files, &ctx, files.len(), arena, arena, true);
+
+        // Totals must agree with what's actually returned on the page (no
+        // separate unordered "count" path to drift out of sync).
+        assert_eq!(total_matched, 1);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].relative_path(arena), "src/handler/auth.rs");
+
+        let offsets =
+            fuzzy_match_byte_offsets_for_page(&parsed, &items, ctx.max_typos, arena, arena, true);
+        assert_eq!(offsets.len(), 1);
+        assert!(
+            !offsets[0].is_empty(),
+            "ordered-mode highlight ranges must be produced for the matched item"
+        );
     }
 
     #[test]
@@ -1575,7 +1870,8 @@ mod typo_resistance_tests {
                 limit: 100,
             },
         };
-        let (items, _, _) = fuzzy_match_and_score_files(files, &ctx, files.len(), arena, arena);
+        let (items, _, _) =
+            fuzzy_match_and_score_files(files, &ctx, files.len(), arena, arena, false);
         items.iter().map(|f| f.relative_path(arena)).collect()
     }
 
@@ -1685,7 +1981,7 @@ mod constraint_only_query_tests {
         };
 
         let (items, _scores, total_matched) =
-            fuzzy_match_and_score_files(&files, &ctx, files.len(), arena, arena);
+            fuzzy_match_and_score_files(&files, &ctx, files.len(), arena, arena, false);
 
         assert_eq!(
             total_matched, 1,
@@ -1736,7 +2032,7 @@ mod constraint_only_query_tests {
         };
 
         let (items, _scores, total_matched) =
-            fuzzy_match_and_score_files(&files, &ctx, files.len(), arena, arena);
+            fuzzy_match_and_score_files(&files, &ctx, files.len(), arena, arena, false);
 
         assert_eq!(total_matched, 1);
         assert_eq!(items[0].relative_path(arena), "a.rs");

--- a/crates/fff-nvim/src/lib.rs
+++ b/crates/fff-nvim/src/lib.rs
@@ -256,6 +256,7 @@ pub fn fuzzy_search_files(
         min_combo_count,
         page_index,
         page_size,
+        ordered_fuzzy_parts,
     ): (
         String,
         usize,
@@ -264,6 +265,7 @@ pub fn fuzzy_search_files(
         Option<u32>,
         Option<usize>,
         Option<usize>,
+        Option<bool>,
     ),
 ) -> LuaResult<LuaValue> {
     let file_picker_guard = FILE_PICKER.read().into_lua_result()?;
@@ -290,7 +292,7 @@ pub fn fuzzy_search_files(
     );
 
     let parsed_query = FFFQuery::parse(&query, FileSearchConfig);
-    let results = picker.fuzzy_search(
+    let results = picker.fuzzy_search_ordered(
         &parsed_query,
         query_tracker_guard.as_ref(),
         FuzzySearchOptions {
@@ -304,6 +306,7 @@ pub fn fuzzy_search_files(
                 limit: page_size.unwrap_or(0),
             },
         },
+        ordered_fuzzy_parts.unwrap_or(false),
     );
 
     if results.items.is_empty() && query.contains(std::path::MAIN_SEPARATOR) {
@@ -341,12 +344,13 @@ pub fn fuzzy_search_files(
 #[allow(clippy::type_complexity)]
 pub fn fuzzy_search_directories(
     lua: &Lua,
-    (query, max_threads, current_file, page_index, page_size): (
+    (query, max_threads, current_file, page_index, page_size, ordered_fuzzy_parts): (
         String,
         usize,
         Option<String>,
         Option<usize>,
         Option<usize>,
+        Option<bool>,
     ),
 ) -> LuaResult<LuaValue> {
     let file_picker_guard = FILE_PICKER.read().into_lua_result()?;
@@ -357,7 +361,7 @@ pub fn fuzzy_search_directories(
     let parser = QueryParser::new(DirSearchConfig);
     let parsed = parser.parse(&query);
 
-    let results = picker.fuzzy_search_directories(
+    let results = picker.fuzzy_search_directories_ordered(
         &parsed,
         FuzzySearchOptions {
             max_threads,
@@ -370,6 +374,7 @@ pub fn fuzzy_search_directories(
                 limit: page_size.unwrap_or(0),
             },
         },
+        ordered_fuzzy_parts.unwrap_or(false),
     );
 
     lua_types::DirSearchResultLua::new(results, picker).into_lua(lua)
@@ -386,6 +391,7 @@ pub fn fuzzy_search_mixed(
         min_combo_count,
         page_index,
         page_size,
+        ordered_fuzzy_parts,
     ): (
         String,
         usize,
@@ -394,6 +400,7 @@ pub fn fuzzy_search_mixed(
         Option<u32>,
         Option<usize>,
         Option<usize>,
+        Option<bool>,
     ),
 ) -> LuaResult<LuaValue> {
     let file_picker_guard = FILE_PICKER.read().into_lua_result()?;
@@ -405,7 +412,7 @@ pub fn fuzzy_search_mixed(
     let parser = QueryParser::new(MixedSearchConfig);
     let parsed = parser.parse(&query);
 
-    let results = picker.fuzzy_search_mixed(
+    let results = picker.fuzzy_search_mixed_ordered(
         &parsed,
         query_tracker_guard.as_ref(),
         FuzzySearchOptions {
@@ -419,6 +426,7 @@ pub fn fuzzy_search_mixed(
                 limit: page_size.unwrap_or(0),
             },
         },
+        ordered_fuzzy_parts.unwrap_or(false),
     );
 
     lua_types::MixedSearchResultLua::new(results, picker).into_lua(lua)

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -419,6 +419,10 @@ local function init()
     file_picker = {
       current_file_label = '(current)',
       fuzzy_query_highlighting = false,
+      -- Require space-separated fuzzy query parts (e.g. "foo bar") to match in the
+      -- order they were typed, as a single fuzzy subsequence, instead of each part
+      -- matching independently anywhere in the candidate. Off by default.
+      ordered_fuzzy_parts = false,
     },
     -- grep settings
     grep = {

--- a/lua/fff/file_picker/init.lua
+++ b/lua/fff/file_picker/init.lua
@@ -65,6 +65,7 @@ function M.search_files_paginated(query, current_file, max_threads, min_combo_co
   if min_combo_count == nil then min_combo_count = config.history and config.history.min_combo_count or 3 end
 
   local combo_boost_score_multiplier = config.history and config.history.combo_boost_score_multiplier or 100
+  local ordered_fuzzy_parts = config.file_picker and config.file_picker.ordered_fuzzy_parts or false
 
   -- Convert page_index to offset (Rust expects offset in items, not page number)
   local offset = page_index * page_size
@@ -77,7 +78,8 @@ function M.search_files_paginated(query, current_file, max_threads, min_combo_co
     combo_boost_score_multiplier,
     min_combo_count,
     offset,
-    page_size
+    page_size,
+    ordered_fuzzy_parts
   )
 
   if not ok then

--- a/lua/fff/main.lua
+++ b/lua/fff/main.lua
@@ -150,7 +150,8 @@ function M.search(query, max_results)
   local max_threads = config.max_threads or 4
   local combo_boost_score_multiplier = config.history and config.history.combo_boost_score_multiplier or 100
   local min_combo_count = config.history and config.history.min_combo_count or 3
-  -- Args: query, max_threads, current_file, combo_boost_score_multiplier, min_combo_count, offset, page_size
+  local ordered_fuzzy_parts = config.file_picker and config.file_picker.ordered_fuzzy_parts or false
+  -- Args: query, max_threads, current_file, combo_boost_score_multiplier, min_combo_count, offset, page_size, ordered_fuzzy_parts
   local ok, search_result = pcall(
     fuzzy.fuzzy_search_files,
     query,
@@ -159,7 +160,8 @@ function M.search(query, max_results)
     combo_boost_score_multiplier,
     min_combo_count,
     0,
-    max_results
+    max_results,
+    ordered_fuzzy_parts
   )
   if ok and search_result.items then return search_result.items end
   return {}
@@ -173,6 +175,7 @@ end
 --- @field max_threads? number Worker threads (default: config.max_threads).
 --- @field combo_boost_score_multiplier? number Override history combo boost.
 --- @field min_combo_count? number Override history min_combo_count.
+--- @field ordered_fuzzy_parts? boolean Override config.file_picker.ordered_fuzzy_parts.
 --- @field cwd? string If set and different from the current indexed root, switch the index to this directory before searching. Implies waiting for the new scan unless `wait_for_index_ms = 0`.
 --- @field wait_for_index_ms? number Block up to this many ms for the index to be ready (default: 10000 when `cwd` triggers a re-index, 0 otherwise). Set to 0 to never block.
 
@@ -287,27 +290,57 @@ function M.file_search(query, opts)
     or (config.history and config.history.combo_boost_score_multiplier)
     or 100
   local min_combo = opts.min_combo_count or (config.history and config.history.min_combo_count) or 3
+  local ordered_fuzzy_parts = opts.ordered_fuzzy_parts
+  if ordered_fuzzy_parts == nil then
+    ordered_fuzzy_parts = config.file_picker and config.file_picker.ordered_fuzzy_parts or false
+  end
 
   local empty = { items = {}, scores = {}, total_matched = 0 }
   if mode == 'files' then
     local offset = page_index * page_size
-    local ok, result =
-      pcall(fuzzy.fuzzy_search_files, query, max_threads, current_file, combo_boost, min_combo, offset, page_size)
+    local ok, result = pcall(
+      fuzzy.fuzzy_search_files,
+      query,
+      max_threads,
+      current_file,
+      combo_boost,
+      min_combo,
+      offset,
+      page_size,
+      ordered_fuzzy_parts
+    )
     if not ok then
       vim.notify('FFF file_search failed: ' .. tostring(result), vim.log.levels.ERROR)
       return empty
     end
     return result
   elseif mode == 'directories' then
-    local ok, result = pcall(fuzzy.fuzzy_search_directories, query, max_threads, current_file, page_index, page_size)
+    local ok, result = pcall(
+      fuzzy.fuzzy_search_directories,
+      query,
+      max_threads,
+      current_file,
+      page_index,
+      page_size,
+      ordered_fuzzy_parts
+    )
     if not ok then
       vim.notify('FFF file_search(directories) failed: ' .. tostring(result), vim.log.levels.ERROR)
       return empty
     end
     return result
   elseif mode == 'mixed' then
-    local ok, result =
-      pcall(fuzzy.fuzzy_search_mixed, query, max_threads, current_file, combo_boost, min_combo, page_index, page_size)
+    local ok, result = pcall(
+      fuzzy.fuzzy_search_mixed,
+      query,
+      max_threads,
+      current_file,
+      combo_boost,
+      min_combo,
+      page_index,
+      page_size,
+      ordered_fuzzy_parts
+    )
     if not ok then
       vim.notify('FFF file_search(mixed) failed: ' .. tostring(result), vim.log.levels.ERROR)
       return empty

--- a/tests/ordered_fuzzy_parts_spec.lua
+++ b/tests/ordered_fuzzy_parts_spec.lua
@@ -1,0 +1,123 @@
+---@diagnostic disable: undefined-field, missing-fields
+-- Config test for the opt-in `file_picker.ordered_fuzzy_parts` setting:
+-- space-separated fuzzy query parts must match in the order they were typed,
+-- as a single fuzzy subsequence, instead of each part matching independently
+-- anywhere in the candidate. Default (off) behavior must stay unchanged.
+
+local fff = require('fff')
+local fff_rust = require('fff.rust')
+local file_picker = require('fff.file_picker')
+
+--- Normalise a path so comparisons work across symlinked temp dirs
+--- (e.g. macOS `/tmp` -> `/private/tmp`). Mirrors picker_dir_resolution_spec.lua.
+--- @param p string
+--- @return string
+local function norm(p)
+  local rp = vim.uv.fs_realpath(p) or vim.fn.fnamemodify(vim.fn.resolve(p), ':p')
+  local n = vim.fs.normalize(rp)
+  n = n:gsub('/$', '')
+  if vim.fn.has('win32') == 1 then n = n:lower() end
+  return n
+end
+
+--- `change_indexing_directory` swaps the picker on a background thread, so the
+--- `FILE_PICKER` global may still point at the *old* picker for a moment —
+--- mirrors the same wait helper in picker_dir_resolution_spec.lua.
+local function wait_for_reindex(expected_dir, timeout_ms)
+  local expected = norm(expected_dir)
+  local deadline = vim.uv.hrtime() + timeout_ms * 1e6
+  while vim.uv.hrtime() < deadline do
+    local ok, health = pcall(fff_rust.health_check, expected)
+    if ok and health and health.file_picker and health.file_picker.base_path then
+      if norm(health.file_picker.base_path) == expected then return true end
+    end
+    vim.wait(20, function() return false end)
+  end
+  return false
+end
+
+local function find_result_by_relative_path(items, relative_path)
+  for _, item in ipairs(items) do
+    if item.relative_path == relative_path or item.relative_path:gsub('\\', '/') == relative_path then
+      return item
+    end
+  end
+  return nil
+end
+
+describe('file_picker.ordered_fuzzy_parts', function()
+  local sandbox_root
+
+  before_each(function()
+    sandbox_root = vim.fn.tempname()
+    vim.fn.mkdir(sandbox_root .. '/src/handler', 'p')
+    vim.fn.mkdir(sandbox_root .. '/auth/src', 'p')
+
+    -- "handler auth" appears in order: src/handler/auth.lua
+    local fd = assert(io.open(sandbox_root .. '/src/handler/auth.lua', 'w'))
+    fd:write('return {}\n')
+    fd:close()
+
+    -- "handler auth" is reversed: auth/src/handler.lua
+    fd = assert(io.open(sandbox_root .. '/auth/src/handler.lua', 'w'))
+    fd:write('return {}\n')
+    fd:close()
+
+    vim.g.fff = {}
+    file_picker.setup()
+
+    -- `require('fff.file_picker')` eagerly calls `ensure_initialized()`,
+    -- which may already have scanned the default cwd by now. Explicitly
+    -- switch to the sandbox and wait for the swap, rather than assuming
+    -- the first init already targeted it.
+    assert.is_true(require('fff.core').change_indexing_directory(sandbox_root))
+    assert.is_true(wait_for_reindex(sandbox_root, 10000), 'reindex to sandbox did not complete')
+    fff_rust.wait_for_initial_scan(30000)
+  end)
+
+  after_each(function()
+    pcall(fff_rust.stop_background_monitor)
+    pcall(fff_rust.cleanup_file_picker)
+    vim.g.fff = nil
+    if sandbox_root then vim.fn.delete(sandbox_root, 'rf') end
+  end)
+
+  it('defaults to off: matches both in-order and reversed paths', function()
+    local result = fff.file_search('handler auth')
+
+    assert.is_true(#result.items >= 2, 'expected both files to match with the default (unordered) matcher')
+    assert.is_not_nil(find_result_by_relative_path(result.items, 'src/handler/auth.lua'))
+    assert.is_not_nil(find_result_by_relative_path(result.items, 'auth/src/handler.lua'))
+  end)
+
+  it('when enabled via opts, only matches the in-order path', function()
+    local result = fff.file_search('handler auth', { ordered_fuzzy_parts = true })
+
+    assert.are.equal(1, #result.items, 'ordered mode should only match the in-order path')
+    assert.is_not_nil(find_result_by_relative_path(result.items, 'src/handler/auth.lua'))
+    assert.is_nil(find_result_by_relative_path(result.items, 'auth/src/handler.lua'))
+  end)
+
+  it('repeated whitespace between parts is ignored under ordered mode', function()
+    local collapsed = fff.file_search('handler auth', { ordered_fuzzy_parts = true })
+    local spaced = fff.file_search('handler   auth', { ordered_fuzzy_parts = true })
+
+    assert.are.equal(1, #collapsed.items)
+    assert.are.equal(#collapsed.items, #spaced.items)
+    assert.are.equal(collapsed.items[1].relative_path, spaced.items[1].relative_path)
+  end)
+
+  it('pagination total_matched agrees with the returned items under ordered mode', function()
+    local result = fff.file_search('handler auth', { ordered_fuzzy_parts = true })
+
+    assert.are.equal(1, result.total_matched)
+    assert.are.equal(result.total_matched, #result.items)
+  end)
+
+  it('directory search mode also respects ordered_fuzzy_parts', function()
+    local off_result = fff.file_search('handler auth', { mode = 'directories' })
+    local on_result = fff.file_search('handler auth', { mode = 'directories', ordered_fuzzy_parts = true })
+
+    assert.is_true(#off_result.items >= #on_result.items)
+  end)
+end)


### PR DESCRIPTION
Adds an opt-in `file_picker.ordered_fuzzy_parts` setting (default off) so a multi-word fuzzy query like `foo bar` can be required to match as one in-order subsequence instead of each space-separated part matching independently anywhere in the candidate.

## Behavior

- **Off by default** — existing single/multi-word fuzzy search, grep (plain/regex/fuzzy), constraints (`*.rs`, `!test`, `/src/`, `type:`, `status:`), query history, and smart-case are all byte-for-byte unchanged.
- When enabled, valid (length-filtered) fuzzy parts are concatenated with **no separator** and routed through the existing single-needle match path (the same one already used for single-token queries) — no new matching algorithm. A space separator was tried first but empirically produced false negatives: a query with several short parts burns its whole typo budget on synthetic space characters that can never appear in a path, and the match is dropped entirely. Concatenating without a separator avoids that; see `test_ordered_fuzzy_parts_many_short_parts_still_match` and `test_ordered_fuzzy_parts_no_literal_space_required_in_candidate` in `score.rs`.
- Highlight recomputation (`fuzzy_match_byte_offsets_for_page`) and directory search share the same join helper (`join_ordered_parts`) and the same length filter as scoring, so highlights and pagination totals always agree with what actually matched.
- Fuzzy grep already joins its parts into a single needle via `FFFQuery::grep_text()` and is therefore already order-sensitive today, independent of this flag — no grep code changes were needed (locked down by `test_fuzzy_grep_multi_word_already_order_sensitive`). Plain-text and regex grep never look at per-part data at all, so they're structurally unaffected.
- Repeated whitespace between parts is a no-op — the parser already collapses it into discrete parts before any joining happens.

## API compatibility

- `FuzzySearchOptions` and `ScoringContext` are unchanged — no source break for `fff-c`, `fff-python`, `fff-mcp`, or the benches/bins.
- `FilePicker::fuzzy_search` / `fuzzy_search_directories` / `fuzzy_search_mixed` keep their exact existing signatures and always score unordered by default; new sibling `*_ordered` methods (explicit `bool` param) hold the actual logic, and are the only thing the Lua bindings call.
- Lua-facing `fuzzy_search_files` / `fuzzy_search_directories` / `fuzzy_search_mixed` gained a new **trailing** `Option<bool>` FFI argument, matching the existing pattern used for `live_grep`'s `smart_case`/`trim_whitespace` — old callers keep working unchanged.

## Tests

- Rust (`cargo test --workspace --no-default-features --features ripgrep --exclude fff-nvim`): all pass, plus new coverage in `score.rs` (ordered vs. unordered matching, repeated whitespace, constraints, smart-case bonus, pagination/highlight consistency, no-literal-space regression, many-short-parts separator-choice regression) and `grep_tests.rs` (order-sensitivity invariant).
- Lua (`PlenaryBustedDirectory tests/`): all 44 specs pass, including a new end-to-end spec (`tests/ordered_fuzzy_parts_spec.lua`) exercising the real FFI path against a built release binary.
- `cargo check -p fff-nvim --all-targets`: clean.

## Known limitation

I could not build or test with the `zlob` walker feature — it needs Zig, which wasn't available in my environment. All the Rust testing above used the default `ripgrep` walker feature instead. Flagging honestly in case CI (which does build `zlob`) catches something that path exposes.