### PR TITLE
Chore: rename fff.nvim repo refs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -612,7 +612,7 @@ jobs:
 
             Update mcp via:
             ```sh
-            curl -fsSL https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.sh | bash
+            curl -fsSL https://raw.githubusercontent.com/dmtrKovalenko/fff/main/install-mcp.sh | bash
             ```
 
       - name: Bump Homebrew formula (uses local checksums)

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,4 @@
--- luacheck configuration for fff.nvim
+-- luacheck configuration for fff
 -- https://luacheck.readthedocs.io/en/stable/config.html
 
 -- Neovim globals

--- a/Formula/fff-mcp.rb
+++ b/Formula/fff-mcp.rb
@@ -2,12 +2,12 @@
 # Maintained in-repo; auto-bumped by .github/workflows/release.yaml on stable releases.
 class FffMcp < Formula
   desc "Fast file search toolkit for AI agents (MCP server)"
-  homepage "https://github.com/dmtrKovalenko/fff.nvim"
+  homepage "https://github.com/dmtrKovalenko/fff"
   license "MIT"
   version "0.10.3"
 
-  LIVECHECK_REPO = "dmtrKovalenko/fff.nvim".freeze
-  RELEASE_BASE = "https://github.com/dmtrKovalenko/fff.nvim/releases/download".freeze
+  LIVECHECK_REPO = "dmtrKovalenko/fff".freeze
+  RELEASE_BASE = "https://github.com/dmtrKovalenko/fff/releases/download".freeze
 
   on_macos do
     on_arm do

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ lint: lint-rust lint-lua lint-ts
 
 check: format lint
 
-FFF_RELEASE_REPO ?= dmtrKovalenko/fff.nvim
+FFF_RELEASE_REPO ?= dmtrKovalenko/fff
 FFF_FORMULA_PATH ?= Formula/fff-mcp.rb
 FFF_INSTALL_SCRIPT_PATH ?= install-mcp.sh
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ curl -L https://dmtrkovalenko.dev/install-fff-mcp.sh | bash
 Windows (PowerShell):
 
 ```powershell
-irm https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.ps1 | iex
+irm https://raw.githubusercontent.com/dmtrKovalenko/fff/main/install-mcp.ps1 | iex
 ```
 
 The scripts live at [`install-mcp.sh`](./install-mcp.sh) and [`install-mcp.ps1`](./install-mcp.ps1) if you want to read them first. They print the exact wiring instructions for your client.
@@ -49,7 +49,7 @@ brew install dmtrKovalenko/fff/fff-mcp
 brew upgrade fff-mcp   # after new stable releases
 ```
 
-Formula lives in [`Formula/fff-mcp.rb`](./Formula/fff-mcp.rb) in this repo and is **auto-bumped on every stable release** (see `bump-homebrew-formula` in [`.github/workflows/release.yaml`](./.github/workflows/release.yaml)). Installs the prebuilt `fff-mcp` binary from [GitHub releases](https://github.com/dmtrKovalenko/fff.nvim/releases).
+Formula lives in [`Formula/fff-mcp.rb`](./Formula/fff-mcp.rb) in this repo and is **auto-bumped on every stable release** (see `bump-homebrew-formula` in [`.github/workflows/release.yaml`](./.github/workflows/release.yaml)). Installs the prebuilt `fff-mcp` binary from [GitHub releases](https://github.com/dmtrKovalenko/fff/releases).
 
 ### Codex setup
 
@@ -154,7 +154,8 @@ https://github.com/user-attachments/assets/5d0e1ce9-642c-4c44-aa88-01b05bb86abb
 
 ```lua
 {
-  'dmtrKovalenko/fff.nvim',
+  'dmtrKovalenko/fff',
+  name = 'fff.nvim', -- keep existing install dir / lockfile identity
   build = function()
     -- downloads a prebuilt binary or falls back to cargo build
     require("fff.download").download_or_build_binary()
@@ -187,7 +188,9 @@ https://github.com/user-attachments/assets/5d0e1ce9-642c-4c44-aa88-01b05bb86abb
 #### vim.pack
 
 ```lua
-vim.pack.add({ 'https://github.com/dmtrKovalenko/fff.nvim' })
+vim.pack.add({
+  { src = 'https://github.com/dmtrKovalenko/fff', name = 'fff.nvim' },
+})
 
 vim.api.nvim_create_autocmd('PackChanged', {
   callback = function(ev)
@@ -614,7 +617,7 @@ cargo build --release -p fff-c --features zlob
 
 The output is a `cdylib` (`libfff_c.so` / `libfff_c.dylib` / `fff_c.dll`). The header lives at [`crates/fff-c/include/fff.h`](./crates/fff-c/include/fff.h).
 
-Prebuilt binaries for every version, including every commit on main, are on the [releases page](https://github.com/dmtrKovalenko/fff.nvim/releases). The same binaries also ship inside the `@ff-labs/fff-bin-*` npm packages.
+Prebuilt binaries for every version, including every commit on main, are on the [releases page](https://github.com/dmtrKovalenko/fff/releases). The same binaries also ship inside the `@ff-labs/fff-bin-*` npm packages.
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ https://github.com/user-attachments/assets/5d0e1ce9-642c-4c44-aa88-01b05bb86abb
 #### lazy.nvim
 
 ```lua
+-- Package name changed from `fff.nvim` to `fff`. If you installed fff.nvim before, clean with `:Lazy clean`
 {
   'dmtrKovalenko/fff',
-  name = 'fff.nvim', -- keep existing install dir / lockfile identity
   build = function()
     -- downloads a prebuilt binary or falls back to cargo build
     require("fff.download").download_or_build_binary()
@@ -188,15 +188,14 @@ https://github.com/user-attachments/assets/5d0e1ce9-642c-4c44-aa88-01b05bb86abb
 #### vim.pack
 
 ```lua
-vim.pack.add({
-  { src = 'https://github.com/dmtrKovalenko/fff', name = 'fff.nvim' },
-})
+-- Package name changed from `fff.nvim` to `fff`. If you installed fff.nvim before, clean with `:packdel fff.nvim`
+vim.pack.add({ 'https://github.com/dmtrKovalenko/fff' })
 
 vim.api.nvim_create_autocmd('PackChanged', {
   callback = function(ev)
     local name, kind = ev.data.spec.name, ev.data.kind
-    if name == 'fff.nvim' and (kind == 'install' or kind == 'update') then
-      if not ev.data.active then vim.cmd.packadd('fff.nvim') end
+    if name == 'fff' and (kind == 'install' or kind == 'update') then
+      if not ev.data.active then vim.cmd.packadd('fff') end
       require('fff.download').download_or_build_binary()
     end
   end,

--- a/crates/fff-core/src/ignore.rs
+++ b/crates/fff-core/src/ignore.rs
@@ -123,7 +123,7 @@ mod tests {
         // Source trees under $HOME stay searchable.
         for rel in [
             "dev/chromium/third_party/blink/renderer/core/dom/node.cc",
-            "dev/fff.nvim/crates/fff-core/src/lib.rs",
+            "dev/fff/crates/fff-core/src/lib.rs",
             "Documents/notes/todo.md",
             "dev/myproj/pkg/mod/thing.go",
         ] {

--- a/crates/fff-core/src/lib.rs
+++ b/crates/fff-core/src/lib.rs
@@ -1,6 +1,6 @@
 //! # FFF Search — High-performance file finder core
 //!
-//! This crate provides the core search engine for [FFF (Fast File Finder)](https://github.com/dmtrKovalenko/fff.nvim).
+//! This crate provides the core search engine for [FFF (Fast File Finder)](https://github.com/dmtrKovalenko/fff).
 //! It includes filesystem indexing with real-time watching, fuzzy matching powered
 //! by [frizbee](https://docs.rs/neo_frizbee), frecency scoring backed by LMDB,
 //! and multi-mode grep search.

--- a/crates/fff-mcp/src/update_check.rs
+++ b/crates/fff-mcp/src/update_check.rs
@@ -1,6 +1,6 @@
 use std::sync::OnceLock;
 
-const REPO: &str = "dmtrKovalenko/fff.nvim";
+const REPO: &str = "dmtrKovalenko/fff";
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 static UPDATE_NOTICE: OnceLock<String> = OnceLock::new();

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -24,9 +24,9 @@ INSTALLATION ~
 LAZY.NVIM
 
 >lua
+    -- Package name changed from `fff.nvim` to `fff`. If you installed fff.nvim before, clean with `:Lazy clean`
     {
       'dmtrKovalenko/fff',
-      name = 'fff.nvim', -- keep existing install dir / lockfile identity
       build = function()
         -- downloads a prebuilt binary or falls back to cargo build
         require("fff.download").download_or_build_binary()
@@ -60,15 +60,14 @@ LAZY.NVIM
 VIM.PACK
 
 >lua
-    vim.pack.add({
-      { src = 'https://github.com/dmtrKovalenko/fff', name = 'fff.nvim' },
-    })
+    -- Package name changed from `fff.nvim` to `fff`. If you installed fff.nvim before, clean with `:packdel fff.nvim`
+    vim.pack.add({ 'https://github.com/dmtrKovalenko/fff' })
     
     vim.api.nvim_create_autocmd('PackChanged', {
       callback = function(ev)
         local name, kind = ev.data.spec.name, ev.data.kind
-        if name == 'fff.nvim' and (kind == 'install' or kind == 'update') then
-          if not ev.data.active then vim.cmd.packadd('fff.nvim') end
+        if name == 'fff' and (kind == 'install' or kind == 'update') then
+          if not ev.data.active then vim.cmd.packadd('fff') end
           require('fff.download').download_or_build_binary()
         end
       end,

--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -25,7 +25,8 @@ LAZY.NVIM
 
 >lua
     {
-      'dmtrKovalenko/fff.nvim',
+      'dmtrKovalenko/fff',
+      name = 'fff.nvim', -- keep existing install dir / lockfile identity
       build = function()
         -- downloads a prebuilt binary or falls back to cargo build
         require("fff.download").download_or_build_binary()
@@ -59,7 +60,9 @@ LAZY.NVIM
 VIM.PACK
 
 >lua
-    vim.pack.add({ 'https://github.com/dmtrKovalenko/fff.nvim' })
+    vim.pack.add({
+      { src = 'https://github.com/dmtrKovalenko/fff', name = 'fff.nvim' },
+    })
     
     vim.api.nvim_create_autocmd('PackChanged', {
       callback = function(ev)

--- a/empty_config.lua
+++ b/empty_config.lua
@@ -1,5 +1,5 @@
--- Single file Neovim config for testing fff.nvim locally
--- Usage: nvim -u /Users/neogoose/dev/fff.nvim/init.lua
+-- Single file Neovim config for testing fff locally
+-- Usage: nvim -u /Users/neogoose/dev/fff/init.lua
 
 -- Set up lazy.nvim plugin manager
 local lazypath = vim.fn.stdpath('data') .. '/lazy/lazy.nvim'
@@ -17,8 +17,8 @@ vim.opt.rtp:prepend(lazypath)
 
 require('lazy').setup({
   {
-    dir = '~/dev/fff.nvim',
-    'https://github.com/dmtrKovalenko/fff.nvim',
+    dir = '~/dev/fff',
+    'https://github.com/dmtrKovalenko/fff',
     build = function()
       -- this will download prebuild binary or try to use existing rustup toolchain to build from source
       -- (if you are using lazy you can use gb for rebuilding a plugin if needed)
@@ -34,7 +34,7 @@ require('lazy').setup({
     },
     config = function()
       require('fff').setup({
-        -- Configure fff.nvim here
+        -- Configure fff here
         ui = {
           width = 0.8,
           height = 0.8,
@@ -59,4 +59,4 @@ vim.keymap.set('n', 'fg', function() require('fff').find_in_git_root() end, { de
 vim.keymap.set('n', 'fr', function() require('fff').scan_files() end, { desc = 'Rescan files' })
 vim.keymap.set('n', 'fs', function() require('fff').refresh_git_status() end, { desc = 'Refresh git status' })
 
-vim.notify('FFF.nvim local config loaded! Press ff', vim.log.levels.INFO)
+vim.notify('FFF local config loaded! Press ff', vim.log.levels.INFO)

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "fff.nvim";
+  description = "fff";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";

--- a/install-mcp.ps1
+++ b/install-mcp.ps1
@@ -4,7 +4,7 @@
     FFF MCP Server installer for Windows.
 .DESCRIPTION
     Pipe usage:
-        irm https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.ps1 | iex
+        irm https://raw.githubusercontent.com/dmtrKovalenko/fff/main/install-mcp.ps1 | iex
     Direct usage (supports params):
         iwr https://.../install-mcp.ps1 -OutFile install-mcp.ps1; .\install-mcp.ps1 -Version v0.1.2
     Env-var fallbacks (for the piped form):
@@ -29,7 +29,7 @@ $ErrorActionPreference = 'Stop'
 # Force TLS 1.2 — PS 5.1 on older Win10 may default to SSL3/TLS1.0 which GitHub rejects.
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
-$Repo = 'dmtrKovalenko/fff.nvim'
+$Repo = 'dmtrKovalenko/fff'
 $BinaryName = 'fff-mcp'
 if (-not $InstallDir) { $InstallDir = Join-Path $env:LOCALAPPDATA 'fff-mcp\bin' }
 

--- a/install-mcp.sh
+++ b/install-mcp.sh
@@ -2,9 +2,9 @@
 set -eo pipefail
 
 # FFF MCP Server installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/dmtrKovalenko/fff.nvim/main/install-mcp.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/dmtrKovalenko/fff/main/install-mcp.sh | bash
 
-REPO="dmtrKovalenko/fff.nvim"
+REPO="dmtrKovalenko/fff"
 BINARY_NAME="fff-mcp"
 INSTALL_DIR="${FFF_MCP_INSTALL_DIR:-$HOME/.local/bin}"
 

--- a/lua/fff/download.lua
+++ b/lua/fff/download.lua
@@ -3,7 +3,7 @@ local system = require('fff.utils.system')
 local fs_utils = require('fff.utils.fs')
 local fff_version = require('fff.utils.version')
 
-local GITHUB_REPO = 'dmtrKovalenko/fff.nvim'
+local GITHUB_REPO = 'dmtrKovalenko/fff'
 
 local function get_binary_dir(plugin_dir) return plugin_dir .. '/../target/release' end
 

--- a/packages/fff-bun/README.md
+++ b/packages/fff-bun/README.md
@@ -174,8 +174,8 @@ If prebuilt binaries aren't available for your platform:
 
 ```bash
 # Clone the repository
-git clone https://github.com/dmtrKovalenko/fff.nvim
-cd fff.nvim
+git clone https://github.com/dmtrKovalenko/fff
+cd fff
 
 # Build the C library
 cargo build --release -p fff-c

--- a/packages/fff-node/README.md
+++ b/packages/fff-node/README.md
@@ -152,8 +152,8 @@ If prebuilt binaries aren't available for your platform:
 
 ```bash
 # Clone the repository
-git clone https://github.com/dmtrKovalenko/fff.nvim
-cd fff.nvim
+git clone https://github.com/dmtrKovalenko/fff
+cd fff
 
 # Build the C library
 cargo build --release -p fff-c

--- a/packages/fff-python/README.md
+++ b/packages/fff-python/README.md
@@ -1,6 +1,6 @@
 # fff-search
 
-Python bindings for [FFF (Fast File Finder)](https://github.com/dmtrKovalenko/fff.nvim), built with [PyO3](https://pyo3.rs/) and [Maturin](https://www.maturin.rs/). Install with `pip install fff-search`; import as `fff`.
+Python bindings for [FFF (Fast File Finder)](https://github.com/dmtrKovalenko/fff), built with [PyO3](https://pyo3.rs/) and [Maturin](https://www.maturin.rs/). Install with `pip install fff-search`; import as `fff`.
 
 ## Requirements
 

--- a/packages/fff-python/pyproject.toml
+++ b/packages/fff-python/pyproject.toml
@@ -15,8 +15,8 @@ dev = [
 ]
 
 [project.urls]
-Repository = "https://github.com/dmtrKovalenko/fff.nvim"
-Issues = "https://github.com/dmtrKovalenko/fff.nvim/issues"
+Repository = "https://github.com/dmtrKovalenko/fff"
+Issues = "https://github.com/dmtrKovalenko/fff/issues"
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]

--- a/packages/pi-fff/README.md
+++ b/packages/pi-fff/README.md
@@ -1,6 +1,6 @@
 # @ff-labs/pi-fff
 
-A [pi](https://github.com/badlogic/pi-mono) extension that replaces the built-in `find` and `grep` tools with [FFF](https://github.com/dmtrKovalenko/fff.nvim) — a Rust-native, SIMD-accelerated file finder with built-in memory.
+A [pi](https://github.com/badlogic/pi-mono) extension that replaces the built-in `find` and `grep` tools with [FFF](https://github.com/dmtrKovalenko/fff) — a Rust-native, SIMD-accelerated file finder with built-in memory.
 
 ## What it does
 
@@ -44,20 +44,20 @@ pi install -l npm:@ff-labs/pi-fff
 **Via git:**
 
 ```bash
-pi install git:github.com/dmtrKovalenko/fff.nvim
+pi install git:github.com/dmtrKovalenko/fff
 ```
 
 Pin to a release:
 
 ```bash
-pi install git:github.com/dmtrKovalenko/fff.nvim@v0.3.0
+pi install git:github.com/dmtrKovalenko/fff@v0.3.0
 ```
 
 ### Local development / manual install
 
 ```bash
-git clone https://github.com/dmtrKovalenko/fff.nvim.git
-cd fff.nvim/packages/pi-fff
+git clone https://github.com/dmtrKovalenko/fff.git
+cd fff/packages/pi-fff
 npm install
 ```
 
@@ -65,14 +65,14 @@ Then add to your pi `settings.json`:
 
 ```json
 {
-  "extensions": ["/path/to/fff.nvim/packages/pi-fff/src/index.ts"]
+  "extensions": ["/path/to/fff/packages/pi-fff/src/index.ts"]
 }
 ```
 
 Or test directly:
 
 ```bash
-pi -e /path/to/fff.nvim/packages/pi-fff/src/index.ts
+pi -e /path/to/fff/packages/pi-fff/src/index.ts
 ```
 
 This extension registers FFF-powered tools (`fffind`, `ffgrep`, `fff-multi-grep`) alongside pi's built-in tools.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -77,4 +77,4 @@ git push origin "$TAG"
 
 echo ""
 echo "Release $VERSION created and pushed."
-echo "CI will build and publish: https://github.com/dmtrKovalenko/fff.nvim/actions"
+echo "CI will build and publish: https://github.com/dmtrKovalenko/fff/actions"

--- a/tests/picker_dir_resolution_spec.lua
+++ b/tests/picker_dir_resolution_spec.lua
@@ -1,5 +1,5 @@
 ---@diagnostic disable: undefined-field, missing-fields
--- Regression test for https://github.com/dmtrKovalenko/fff.nvim/issues/389
+-- Regression test for https://github.com/dmtrKovalenko/fff/issues/389
 -- When find_files_in_dir(dir) runs with dir != neovim's cwd, the Rust indexer
 -- reports paths relative to `dir`, but the Lua side used to resolve them
 -- against neovim's cwd when calling :edit / preview / quickfix — so files

--- a/tests/programmatic_search_spec.lua
+++ b/tests/programmatic_search_spec.lua
@@ -31,7 +31,7 @@ local function find_result_by_name(items, name)
 end
 
 describe('programmatic search APIs', function()
-  describe('against the actual fff.nvim repo', function()
+  describe('against the actual fff repo', function()
     before_each(function()
       pcall(vim.api.nvim_del_augroup_by_name, 'fff_file_tracking')
       vim.g.fff = {}
@@ -181,9 +181,9 @@ describe('programmatic search APIs', function()
       fd:write('-- only lives in the other sandbox\n')
       fd:close()
 
-      -- Sanity: the file does not exist in the primary (fff.nvim) index.
+      -- Sanity: the file does not exist in the primary (fff) index.
       local before = fff.file_search(other_filename)
-      assert.are.equal(0, #before.items, 'sandbox file leaked into primary fff.nvim index')
+      assert.are.equal(0, #before.items, 'sandbox file leaked into primary fff index')
 
       local result = fff.file_search(other_filename, { cwd = sandbox_root })
       assert.is_true(#result.items > 0, 'cwd switch did not surface file from the new root')
@@ -202,7 +202,7 @@ describe('programmatic search APIs', function()
       sandbox_root = vim.fn.tempname() .. '_other_grep'
       vim.fn.mkdir(sandbox_root, 'p')
       -- Build the marker by concatenation so the literal string doesn't
-      -- appear anywhere in the fff.nvim tree (otherwise the "before" grep
+      -- appear anywhere in the fff tree (otherwise the "before" grep
       -- would find this very test file via its own marker constant).
       local marker = 'isolated_grep' .. '_marker_xyzzy'
       local fd = assert(io.open(sandbox_root .. '/grep_target.lua', 'w'))
@@ -214,9 +214,9 @@ describe('programmatic search APIs', function()
       -- this is fine in practice cause this is not a real use case for fff to search RIGHT AFTER mkdir
       if vim.fn.has('win32') == 1 then vim.wait(250, function() return false end) end
 
-      -- Marker must not exist anywhere in the primary fff.nvim tree.
+      -- Marker must not exist anywhere in the primary fff tree.
       local before = fff.content_search(marker)
-      assert.are.equal(0, #before.items, 'marker leaked into primary fff.nvim tree')
+      assert.are.equal(0, #before.items, 'marker leaked into primary fff tree')
 
       local result = fff.content_search(marker, { cwd = sandbox_root })
       assert.is_true(#result.items > 0, 'cwd switch did not surface match from the new root')


### PR DESCRIPTION
I found while installing from the repo docs that several references use the outdated `github.com/dmtrKovalenko/fff.nvim` repo name. The 301 redirect prevented this from causing an error during install but it was confusing.

This change updates docs and metadata files to use the new name.

## Summary

- Update residual `dmtrKovalenko/fff.nvim` repository URLs to `dmtrKovalenko/fff` after the GitHub repo rename (download.lua, MCP installers, Homebrew formula, docs, package metadata).
- Keep Neovim product identity where it is still valid (help tags, health, flake pname, frontend label)
- Two commits:

1. New URLs + preserve package name `fff.nvim` to minimize upgrade pain for existing nvim users that update their config from the docs.
2. Optional docs cleanup so package name aligns with repo basename `fff` with a comment for migrating users. This may cause some issues for nvim users that update their config from the docs, so this is split into a separate commit that can be dropped if desired.

## Questions

1. Accept both commits, or just commit 1?
2. Also rename help/`pname`/health from `fff.nvim` to `fff`?