### PR TITLE
fix(pi-fff): fall back to transient finder when LMDB env already open (#760)

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -259,6 +259,13 @@ function buildAtCompletionValue(path: string): string {
   return path.includes(" ") ? `@"${path}"` : `@${path}`;
 }
 
+// heed refuses to reopen an LMDB env already open in the process, surfaced
+// through FileFinder.create() as this error string. Matched to fall back to a
+// transient (no-DB) finder for in-process subagents — see #760.
+function isEnvAlreadyOpenError(error: string): boolean {
+  return /environment already open/i.test(error);
+}
+
 function createFffMentionProvider(
   getItems: (query: string, signal: AbortSignal) => Promise<AutocompleteItem[]>,
 ): AutocompleteProvider {
@@ -396,7 +403,7 @@ export default function fffExtension(pi: ExtensionAPI) {
       }
 
       const { FileFinder } = await loadSdk();
-      const result = FileFinder.create({
+      let result = FileFinder.create({
         basePath: cwd,
         frecencyDbPath,
         historyDbPath,
@@ -404,6 +411,21 @@ export default function fffExtension(pi: ExtensionAPI) {
         enableHomeDirScanning,
         enableFsRootScanning,
       });
+
+      // In-process subagents (createAgentSession) load this extension a second
+      // time in the same process. LMDB opens an env at most once per path per
+      // process, so the shared frecency/history DBs are already owned by the
+      // parent session's finder — reopening them fails. Fall back to a
+      // transient finder without persistent scoring, exactly like aux finders
+      // do (#700). See #760.
+      if (!result.ok && isEnvAlreadyOpenError(result.error)) {
+        result = FileFinder.create({
+          basePath: cwd,
+          aiMode: true,
+          enableHomeDirScanning,
+          enableFsRootScanning,
+        });
+      }
 
       if (!result.ok)
         throw new Error(`Failed to create FFF file finder: ${result.error}`);

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -49,10 +49,16 @@ function createMockFinder(): MockFinder {
   };
 }
 
+let createImpl: ((options: unknown) => unknown) | undefined;
+
 const finderModule = {
   FileFinder: {
     create: mock((options: unknown) => {
       createCalls.push(options);
+      if (createImpl) {
+        const override = createImpl(options);
+        if (override !== undefined) return override;
+      }
       const finder = createMockFinder();
       finders.push(finder);
       return { ok: true, value: finder };
@@ -163,6 +169,7 @@ beforeEach(() => {
   createCalls.length = 0;
   finders = [];
   mixedSearchImpl = undefined;
+  createImpl = undefined;
   scanProgressImpl = undefined;
   delete process.env.PI_FFF_MODE;
   delete process.env.FFF_ENABLE_HOME_SCAN;
@@ -254,6 +261,43 @@ describe("pi-fff autocomplete registration", () => {
 
     const opts = createCalls[0] as { enableHomeDirScanning: boolean };
     expect(opts.enableHomeDirScanning).toBe(false);
+  });
+
+  // In-process subagents (createAgentSession) reopen the shared LMDB env,
+  // which fails. The main finder must fall back to a transient no-DB finder
+  // instead of throwing during session_start — see #760.
+  test("falls back to a transient finder when the LMDB env is already open", async () => {
+    process.env.FFF_FRECENCY_DB = "/tmp/fff-test/frecency";
+    process.env.FFF_HISTORY_DB = "/tmp/fff-test/history";
+    let firstCall = true;
+    createImpl = () => {
+      if (firstCall) {
+        firstCall = false;
+        return {
+          ok: false,
+          error:
+            "Failed to init frecency db: Failed to open frecency database env: environment already open in this program; close it to be able to open it again with different options",
+        };
+      }
+      return undefined;
+    };
+
+    const { ctx } = await start();
+
+    expect(ctx.ui.notify).not.toHaveBeenCalledWith(
+      expect.stringContaining("FFF init failed"),
+      "error",
+    );
+    expect(createCalls).toHaveLength(2);
+    const retry = createCalls[1] as {
+      frecencyDbPath?: string;
+      historyDbPath?: string;
+    };
+    expect(retry.frecencyDbPath).toBeUndefined();
+    expect(retry.historyDbPath).toBeUndefined();
+
+    delete process.env.FFF_FRECENCY_DB;
+    delete process.env.FFF_HISTORY_DB;
   });
 
   test("session_start survives hosts without addAutocompleteProvider", async () => {


### PR DESCRIPTION
Closes #760

## Root cause
heed 0.22 keeps a process-global `OPENED_ENV` registry (`env_open_options.rs:405-422`); opening the same canonical LMDB path twice in one process returns `Error::EnvAlreadyOpened`. pi-fff's main finder always opens the fixed `~/.pi/agent/fff/{frecency,history}` (`packages/pi-fff/src/index.ts:313-321`), so an in-process subagent (`createAgentSession`) that loads the extension a second time hits this on `FileFinder.create()`. #700 fixed only aux finders, not the main finder.

## Fix
When `ensureFinder` gets `EnvAlreadyOpened` from `FileFinder.create()`, retry once without `frecencyDbPath`/`historyDbPath` — a transient finder without persistent scoring, exactly like aux finders (#700). `packages/pi-fff/src/index.ts`.

## Steps to reproduce
Rust layer (proves the engine-level cause), add to `crates/fff-core/src/dbs/frecency.rs` tests and run `cargo test -p fff-search`:

```rust
#[test]
fn repro_760() {
    let dir = std::env::temp_dir().join("fff_repro_760");
    let _ = std::fs::remove_dir_all(&dir);
    assert!(FrecencyTracker::open(dir.to_str().unwrap()).is_ok());   // first open
    let b = FrecencyTracker::open(dir.to_str().unwrap());            // second open, same process
    if let Err(e) = &b { eprintln!("{e}"); }
    assert!(b.is_ok());                                             // FAILS on pre-fix main
}
```

Pre-fix actual output:

```
SECOND OPEN ERROR: Failed to open frecency database env: environment already open in this program; close it to be able to open it again with different options
```

Expected: second open succeeds (or the caller degrades gracefully). In pi-fff this surfaces as `FFF init failed: ...environment already open...` on subagent start.

## How verified
```
bun test test/     # packages/pi-fff -> 56 pass, 0 fail (adds a fallback test)
```
The new test `falls back to a transient finder when the LMDB env is already open` forces `create()` to return `EnvAlreadyOpened` once and asserts the retry drops the DB paths and session_start does not error.

Automated triage via Gustav. Honk-Honk 🪿
