### PR TITLE
fix(grep): keep FilePath scope in regex/literal fallback (#756)

### DIFF
--- a/crates/fff-core/src/grep/grep.rs
+++ b/crates/fff-core/src/grep/grep.rs
@@ -229,9 +229,19 @@ pub(crate) fn grep_search<'a>(
         return result;
     }
 
+    // Keep any explicit FilePath scope (AI mode `path/to/file.ext` prefix) so the
+    // fallback can't leak matches outside the file the user pinned. Only the
+    // swallowed operator/glob tokens are dropped. See issue #756.
+    let scoped_constraints: fff_query_parser::ConstraintVec<'_> = query
+        .constraints
+        .iter()
+        .filter(|c| matches!(c, fff_query_parser::Constraint::FilePath(_)))
+        .cloned()
+        .collect();
+
     let literal_query = FFFQuery {
         raw_query: query.raw_query,
-        constraints: Vec::new(),
+        constraints: scoped_constraints,
         fuzzy_query: fff_query_parser::FuzzyQuery::Text(raw),
         location: None,
     };

--- a/crates/fff-core/src/grep/grep_tests.rs
+++ b/crates/fff-core/src/grep/grep_tests.rs
@@ -503,7 +503,11 @@ fn regex_fallback_keeps_file_path_scope_issue_756() {
     let raw = r"scope/target.css ^/\* |^\s*/\* ----------";
     let query = QueryParser::new(AiGrepConfig).parse(raw);
     let result = picker.grep(&query, &options);
-    let mut paths: Vec<String> = result.files.iter().map(|f| f.relative_path(&picker)).collect();
+    let mut paths: Vec<String> = result
+        .files
+        .iter()
+        .map(|f| f.relative_path(&picker))
+        .collect();
     paths.sort();
 
     assert_eq!(

--- a/crates/fff-core/src/grep/grep_tests.rs
+++ b/crates/fff-core/src/grep/grep_tests.rs
@@ -461,3 +461,54 @@ fn test_grep_no_duplicates_with_overflow_trailing_bits() {
         result.matches.len()
     );
 }
+
+/// Issue #756: an AI-mode regex query with an inline FilePath scope and
+/// top-level alternation. The regex fragments are swallowed as bogus Glob
+/// constraints, the constrained search finds nothing, and the literal/regex
+/// fallback must NOT drop the FilePath scope — otherwise the `|` branch leaks
+/// matches into files outside the pinned path.
+#[test]
+fn regex_fallback_keeps_file_path_scope_issue_756() {
+    use fff_query_parser::{AiGrepConfig, QueryParser};
+    let dir = tempfile::tempdir().unwrap();
+    let base = crate::path_utils::canonicalize(dir.path()).unwrap();
+    std::fs::create_dir(base.join("scope")).unwrap();
+    std::fs::write(
+        base.join("scope").join("target.css"),
+        "/* ---------- target ---------- */\n",
+    )
+    .unwrap();
+    std::fs::write(
+        base.join("outside.css"),
+        "/* ---------- outside ---------- */\n",
+    )
+    .unwrap();
+
+    let mut picker = FilePicker::new(FilePickerOptions {
+        base_path: base.to_str().unwrap().into(),
+        watch: false,
+        ..Default::default()
+    })
+    .unwrap();
+    picker.collect_files().unwrap();
+
+    let options = crate::GrepSearchOptions {
+        mode: super::GrepMode::Regex,
+        smart_case: true,
+        max_matches_per_file: 80,
+        page_limit: 100,
+        ..Default::default()
+    };
+
+    let raw = r"scope/target.css ^/\* |^\s*/\* ----------";
+    let query = QueryParser::new(AiGrepConfig).parse(raw);
+    let result = picker.grep(&query, &options);
+    let mut paths: Vec<String> = result.files.iter().map(|f| f.relative_path(&picker)).collect();
+    paths.sort();
+
+    assert_eq!(
+        paths,
+        vec!["scope/target.css"],
+        "regex fallback must not leak outside the FilePath scope"
+    );
+}


### PR DESCRIPTION
Closes #756

## Root cause
Two layers. The AI-mode parser splits on whitespace, so regex fragments `^/\*` and `|^\s*/\*` (both contain `/`+`*`) are misparsed as `Glob` constraints, leaving only `----------` as grep text. Those bogus globs match nothing, so the constrained search is empty and the literal/regex fallback at `crates/fff-core/src/grep/grep.rs:232` rebuilt the query with `constraints: Vec::new()`, discarding the user's `FilePath("scope/target.css")` scope. In regex mode the raw query is then re-run whole and the top-level `|` branch `^\s*/\* ----------` matches `/* ----------` in every file.

## Fix
`crates/fff-core/src/grep/grep.rs`: the fallback now preserves `FilePath` constraints (only the swallowed operator/glob tokens are dropped), so a pinned path can't be escaped. Regression test added in `grep_tests.rs`.

## Steps to reproduce
On pre-fix `origin/main`:
```sh
mkdir /tmp/fff-756 && cd /tmp/fff-756
npm init -y && npm install @ff-labs/fff-node@0.10.3
```
Save `repro.mjs` from the issue, then:
```sh
node repro.mjs ./out.log
```
Expected: `actualPaths` limited to `["scope/target.css"]`, `filteredFileCount`/`totalFilesSearched` = 1.
Actual (pre-fix):
```json
{"actualPaths":["outside.css","scope/target.css"],"totalMatched":2,"filteredFileCount":2,"totalFilesSearched":2}
```

## How verified
Added e2e regression test reproducing the exact query through the core pipeline (AiGrepConfig + regex mode):
```
cargo test -p fff-search grep
# test result: ok. 6 passed; 0 failed  (incl. regex_fallback_keeps_file_path_scope_issue_756)
cargo test -p fff-search --test grep_integration
# test result: ok. 68 passed; 0 failed
cargo clippy -p fff-search   # clean
```
Pre-fix the new test yields `["outside.css","scope/target.css"]`; post-fix `["scope/target.css"]`.

Automated triage via Gustav. Honk-Honk 🪿
