### PR TITLE
fix: add missing clap attribute to no_content_indexing (#754)

### DIFF
--- a/crates/fff-mcp/src/main.rs
+++ b/crates/fff-mcp/src/main.rs
@@ -131,6 +131,7 @@ pub(crate) struct Args {
 
     /// Disable the content index built after the initial scan.
     /// This makes grep calls slower but consumes less RAM (recommended to not turn off)
+    #[arg(long = "no-content-indexing")]
     no_content_indexing: bool,
 
     /// Explicitly enable content indexing even when `--no-warmup` is set.


### PR DESCRIPTION
Closes #754

## Root cause
`crates/fff-mcp/src/main.rs:134` declared the `no_content_indexing: bool` field without an `#[arg(long = ...)]` attribute. clap therefore treated it as a positional argument with a `SetTrue` action, which is invalid.

## Fix
Added `#[arg(long = "no-content-indexing")]` to the field, matching the adjacent `--no-warmup` / `--no-watch` flags.

## Steps to reproduce
On pre-fix `origin/main` (`b6f351d`):

```sh
cargo run -p fff-mcp -- --help
```

Expected: help text listing a `--no-content-indexing` boolean option.

Actual (debug build): panic before any output —

```text
thread 'main' panicked at clap_builder-4.6.0/src/builder/debug_asserts.rs:746:9:
Argument 'no_content_indexing' is positional and it must take a value but action is SetTrue
```

Release builds instead expose `[NO_CONTENT_INDEXING]` as a positional and reject `--no-content-indexing`.

## How verified
```sh
cargo run -p fff-mcp -- --help
```

Now exits 0 and lists the flag:

```text
      --no-content-indexing
          Disable the content index built after the initial scan.
          This makes grep calls slower but consumes less RAM (recommended to not turn off)
```

Automated triage via Gustav. Honk-Honk 🪿