### PR TITLE
fix: rebuild file picker after FFFClearCache files (#772)

### DIFF
--- a/lua/fff/core.lua
+++ b/lua/fff/core.lua
@@ -135,11 +135,17 @@ M.change_indexing_directory = function(new_path)
   return true
 end
 
-M.ensure_initialized = function()
-  if state.initialized then return fuzzy end
+--- Reset the file-picker flag so the next `ensure_initialized` recreates the
+--- Rust picker. Call after `cleanup_file_picker` drops it (`FFFClearCache`);
+--- otherwise the flag stays set and every later call operates on a dropped
+--- picker (see #772).
+M.mark_file_picker_uninitialized = function() state.file_picker_initialized = false end
 
+M.ensure_initialized = function()
   local config = require('fff.conf').get()
 
+  -- Refusal gates both one-time setup and (re)creating the picker so we never
+  -- index fs-root / home, even after a cache clear.
   -- Some folks are complaining that neovim instance is closing if ffi returns error on startup (via lazy=false)
   -- I can't repro so just precheck on lua side to prevent crashing neovim instance
   local refusal = fs_scanning_refusal(config)
@@ -149,45 +155,52 @@ M.ensure_initialized = function()
     return fuzzy
   end
 
-  state.initialized = true
-  if config.logging.enabled then
-    local log_success, log_error =
-      pcall(fuzzy.init_tracing, config.logging.log_file, config.logging.log_level, config.logging.retain_runs)
-    if log_success then
-      M.log_file_path = log_error
-    else
-      vim.notify('Failed to initialize logging: ' .. (tostring(log_error) or 'unknown error'), vim.log.levels.WARN)
+  if not state.initialized then
+    state.initialized = true
+    if config.logging.enabled then
+      local log_success, log_error =
+        pcall(fuzzy.init_tracing, config.logging.log_file, config.logging.log_level, config.logging.retain_runs)
+      if log_success then
+        M.log_file_path = log_error
+      else
+        vim.notify('Failed to initialize logging: ' .. (tostring(log_error) or 'unknown error'), vim.log.levels.WARN)
+      end
     end
+
+    local frecency_db_path = config.frecency.db_path or (vim.fn.stdpath('cache') .. '/fff_frecency')
+    local history_db_path = config.history.db_path or (vim.fn.stdpath('data') .. '/fff_history')
+
+    local ok, result = pcall(fuzzy.init_db, frecency_db_path, history_db_path, true)
+    if not ok then vim.notify('Failed to databases: ' .. tostring(result), vim.log.levels.WARN) end
+
+    setup_global_autocmds(config)
+
+    local highlights = require('fff.highlights')
+    highlights.setup()
+
+    vim.api.nvim_create_autocmd('ColorScheme', {
+      group = vim.api.nvim_create_augroup('fff_highlights', { clear = true }),
+      callback = function() highlights.setup() end,
+      desc = 'Re-apply FFF highlights on colorscheme change',
+    })
   end
 
-  local frecency_db_path = config.frecency.db_path or (vim.fn.stdpath('cache') .. '/fff_frecency')
-  local history_db_path = config.history.db_path or (vim.fn.stdpath('data') .. '/fff_history')
-
-  local ok, result = pcall(fuzzy.init_db, frecency_db_path, history_db_path, true)
-  if not ok then vim.notify('Failed to databases: ' .. tostring(result), vim.log.levels.WARN) end
-
-  ok, result = pcall(fuzzy.init_file_picker, config.base_path, {
-    follow_symlinks = config.follow_symlinks,
-    enable_fs_root_scanning = config.enable_fs_root_scanning,
-    enable_home_dir_scanning = config.enable_home_dir_scanning,
-    enable_filename_constraint = config.grep and config.grep.enable_filename_constraint,
-  })
-  if not ok then
-    vim.notify('Failed to initialize file picker: ' .. tostring(result), vim.log.levels.ERROR)
-    return fuzzy
+  -- Recreated whenever the picker was torn down (e.g. `FFFClearCache files`).
+  -- Guarded separately from one-time setup so a cache clear rebuilds the
+  -- picker instead of leaving a dropped one behind (#772).
+  if not state.file_picker_initialized then
+    local ok, result = pcall(fuzzy.init_file_picker, config.base_path, {
+      follow_symlinks = config.follow_symlinks,
+      enable_fs_root_scanning = config.enable_fs_root_scanning,
+      enable_home_dir_scanning = config.enable_home_dir_scanning,
+      enable_filename_constraint = config.grep and config.grep.enable_filename_constraint,
+    })
+    if not ok then
+      vim.notify('Failed to initialize file picker: ' .. tostring(result), vim.log.levels.ERROR)
+      return fuzzy
+    end
+    state.file_picker_initialized = true
   end
-
-  state.file_picker_initialized = true
-  setup_global_autocmds(config)
-
-  local highlights = require('fff.highlights')
-  highlights.setup()
-
-  vim.api.nvim_create_autocmd('ColorScheme', {
-    group = vim.api.nvim_create_augroup('fff_highlights', { clear = true }),
-    callback = function() highlights.setup() end,
-    desc = 'Re-apply FFF highlights on colorscheme change',
-  })
 
   return fuzzy
 end

--- a/lua/fff/main.lua
+++ b/lua/fff/main.lua
@@ -101,7 +101,13 @@ function M.clear_cache(scope)
 
   if scope == 'all' or scope == 'files' then
     local ok, err = pcall(fuzzy.cleanup_file_picker)
-    if not ok then table.insert(errors, 'cleanup file picker: ' .. tostring(err)) end
+    if not ok then
+      table.insert(errors, 'cleanup file picker: ' .. tostring(err))
+    else
+      -- Rust picker is gone; clear the core flag so the next ensure_initialized
+      -- rebuilds it instead of operating on a dropped picker (#772).
+      require('fff.core').mark_file_picker_uninitialized()
+    end
   end
 
   if scope == 'all' or scope == 'frecency' then


### PR DESCRIPTION
Closes #772

## Root cause
`clear_cache('files')` drops the Rust picker (`lua/fff/main.lua` → `fuzzy.cleanup_file_picker` → `FILE_PICKER.take()`), but `lua/fff/core.lua` never cleared `state.file_picker_initialized`. `ensure_initialized()` short-circuited on `state.initialized` (`core.lua:139` pre-fix), so it never rebuilt the picker. Every subsequent `FFFScan`/search then ran against a `None` picker — the watcher logs `File picker not initialized` (`crates/fff-core/src/watcher/background_watcher.rs:548`) right before the SIGSEGV on Linux.

## Fix
Split `ensure_initialized`: one-time setup (tracing/db/autocmds/highlights) stays gated on `state.initialized`; picker creation is now gated separately on `state.file_picker_initialized`. `clear_cache` calls the new `core.mark_file_picker_uninitialized()` after tearing the picker down, so the next `ensure_initialized()` rebuilds it.

## Steps to reproduce
On pre-fix `origin/main` (`cc289f0`):

```sh
# from the fff checkout, with the release lib built (make build)
nvim --headless -u NONE --cmd "set rtp+=$PWD" \
  "+runtime plugin/fff.lua" \
  "+lua require('fff.core').ensure_initialized()" "+lua vim.wait(500)" \
  "+lua print('before='..tostring(require('fff.rust').health_check().file_picker.initialized))" \
  "+FFFClearCache files" \
  "+lua require('fff.core').ensure_initialized()" "+lua vim.wait(400)" \
  "+lua print('after ='..tostring(require('fff.rust').health_check().file_picker.initialized))" +qa
```

Expected: `before=true` then `after=true` (picker rebuilt).
Actual on pre-fix `main`: `before=true` then `after=false` — the picker is never recreated. The reporter's original repro then SIGSEGVs on Linux:

```sh
nvim --headless "+lua require(\"fff.core\").ensure_initialized()" "+FFFClearCache files" "+FFFScan" "+sleep 2" +qa
# exit 139, log: "File picker not initialized" then "=== CRASH SIGSEGV (fff) ==="
```

## How verified
Post-fix, same repro (macOS, `make build`):

```text
before=true
after =true      # picker rebuilt
```

Search works before and after the clear (pre-fix returned 0 after clear):

```text
search hits=5
Cleared FFF cache: files
search-after-clear hits=5
```

Reporter's exact command now exits 0 with no `Failed to scan files` and no crash (3/3 runs). `stylua --check lua/fff/core.lua lua/fff/main.lua` passes.

Automated triage via Gustav. Honk-Honk 🪿


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-picker recovery after clearing the cache.
  * File-picker setup can now be recreated without repeating unrelated initialization.
  * Cleanup and initialization errors are reported more reliably.
  * Prevented filesystem scanning when setup cannot proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->