### PR TITLE
fix(mcp): declare readOnlyHint on find_files/grep/multi_grep (#771)

### DIFF
--- a/crates/fff-mcp/src/server.rs
+++ b/crates/fff-mcp/src/server.rs
@@ -421,7 +421,12 @@ impl FffServer {
     /// IMPORTANT: Keep queries SHORT — prefer 1-2 terms max.
     #[tool(
         name = "find_files",
-        description = "Fuzzy file search by name. Searches FILE NAMES, not file contents. Use it when you need to find a file, not a definition. Use grep instead for searching code content (definitions, usage patterns). Supports fuzzy matching, path prefixes ('src/'), and glob constraints ('name **/src/*.{ts,tsx} !test/'). IMPORTANT: Keep queries SHORT — prefer 1-2 terms max. Multiple words are a waterfall (each narrows results), NOT OR. If unsure, start broad with 1 term and refine."
+        description = "Fuzzy file search by name. Searches FILE NAMES, not file contents. Use it when you need to find a file, not a definition. Use grep instead for searching code content (definitions, usage patterns). Supports fuzzy matching, path prefixes ('src/'), and glob constraints ('name **/src/*.{ts,tsx} !test/'). IMPORTANT: Keep queries SHORT — prefer 1-2 terms max. Multiple words are a waterfall (each narrows results), NOT OR. If unsure, start broad with 1 term and refine.",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            open_world_hint = false
+        )
     )]
     fn find_files(
         &self,
@@ -536,7 +541,12 @@ impl FffServer {
     /// Prefer plain text over regex. Filter files with constraints.
     #[tool(
         name = "grep",
-        description = "Search file contents. Search for bare identifiers (e.g. 'InProgressQuote', 'ActorAuth'), NOT code syntax or regex. Filter files with constraints (e.g. '*.rs query', 'src/ query'). Use filename, directory (ending with /) or glob expressions to prefilter. See server instructions for constraint syntax and core rules."
+        description = "Search file contents. Search for bare identifiers (e.g. 'InProgressQuote', 'ActorAuth'), NOT code syntax or regex. Filter files with constraints (e.g. '*.rs query', 'src/ query'). Use filename, directory (ending with /) or glob expressions to prefilter. See server instructions for constraint syntax and core rules.",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            open_world_hint = false
+        )
     )]
     fn grep(
         &self,
@@ -573,7 +583,12 @@ impl FffServer {
     /// Patterns are literal text — NEVER escape special characters.
     #[tool(
         name = "multi_grep",
-        description = "Search file contents for lines matching ANY of multiple patterns (OR logic). IMPORTANT: This returns files where ANY query matches, NOT all patterns. Patterns are literal text — NEVER escape special characters (no \\( \\) \\. etc). Faster than regex alternation for literal text. See server instructions for constraint syntax."
+        description = "Search file contents for lines matching ANY of multiple patterns (OR logic). IMPORTANT: This returns files where ANY query matches, NOT all patterns. Patterns are literal text — NEVER escape special characters (no \\( \\) \\. etc). Faster than regex alternation for literal text. See server instructions for constraint syntax.",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            open_world_hint = false
+        )
     )]
     fn multi_grep(
         &self,


### PR DESCRIPTION
Closes #771

## Root cause
The three `#[tool]` macros in `crates/fff-mcp/src/server.rs:422`, `:537`, and `:574` declared no `annotations`, so `tools/list` returned `annotations: null`. Clients that gate read-only access by `readOnlyHint` (plan mode, read-only sub-agents) treat missing annotations as potentially-mutating and block every fff tool, even though fff only reads the filesystem.

## Fix
Add `annotations(read_only_hint = true, destructive_hint = false, open_world_hint = false)` to each of the three `#[tool]` attributes (`find_files`, `grep`, `multi_grep`). rmcp's macro emits these into the `tools/list` response.

## Steps to reproduce
Pre-fix, on `origin/main`:

```sh
cargo build -p fff-mcp
cd /tmp && mkdir -p fff-mcp-repro && cd fff-mcp-repro && printf 'hello\n' > a.txt
BIN=/path/to/fff/target/debug/fff-mcp
printf '%s\n' \
'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"r","version":"0"}}}' \
'{"jsonrpc":"2.0","method":"notifications/initialized"}' \
'{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' | "$BIN"
```

Expected: `find_files`, `grep`, `multi_grep` each carry `"annotations": {"readOnlyHint": true, "destructiveHint": false}`.
Actual (pre-fix): each tool has `"annotations": null`.

## How verified
Rebuilt and re-ran the repro above:

```
find_files annotations= {"readOnlyHint": true, "destructiveHint": false, "openWorldHint": false}
grep       annotations= {"readOnlyHint": true, "destructiveHint": false, "openWorldHint": false}
multi_grep annotations= {"readOnlyHint": true, "destructiveHint": false, "openWorldHint": false}
```

`cargo build -p fff-mcp` clean. Diff is 6 insertions / 3 deletions in one file.

Automated triage via Gustav. Honk-Honk 🪿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified descriptions for file-finding and search tools.
  * Added guidance indicating these tools are read-only, non-destructive, and operate within a defined scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->