### PR TITLE
perf(ci): cut CI wall clock from ~50m to ~14m

### DIFF
--- a/.github/workflows/external-tests.yml
+++ b/.github/workflows/external-tests.yml
@@ -29,6 +29,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     # e2e tests could be flaky on CI so we do not block release creation if they failed
     continue-on-error: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    # alpine-musl installs rust via apk and has no sccache, so keep this scoped.
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
     strategy:
       fail-fast: false
       matrix:
@@ -53,9 +57,19 @@ jobs:
           cache-key: "v2-lua-e2e"
           rustflags: ""
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.17.0
+
       - name: Build Rust binary
         shell: bash
         run: make build-e2e
+
+      - name: sccache stats
+        if: always()
+        shell: bash
+        run: sccache --show-stats
 
       - name: Verify Windows DLL has no unexpected dependencies
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/external-tests.yml
+++ b/.github/workflows/external-tests.yml
@@ -23,6 +23,10 @@ env:
   CARGO_PROFILE_RELEASE_LTO: thin
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   lua-tests:
     name: e2e (${{ matrix.os }})
@@ -33,6 +37,9 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
+      # fff-search alone exceeds the 600s default on windows, and the server
+      # sees no new requests while it compiles, so it would idle out mid-unit.
+      SCCACHE_IDLE_TIMEOUT: "0"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lua.yml
+++ b/.github/workflows/lua.yml
@@ -12,6 +12,10 @@ on:
       - '**.md'
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   lua-ls:
     name: lua-language-server type check

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,6 +12,10 @@ on:
       - '**.md'
       - 'doc/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   check:
     runs-on: ubuntu-22.04

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,6 +19,13 @@ env:
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: sccache
+  # fff-search alone exceeds the 600s default on windows, and the server sees
+  # no new requests while it compiles, so it would idle out mid-unit.
+  SCCACHE_IDLE_TIMEOUT: "0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   test:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,6 +17,8 @@ env:
   MACOSX_DEPLOYMENT_TARGET: "13.0"
   CARGO_PROFILE_RELEASE_LTO: thin
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: 16
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: sccache
 
 jobs:
   test:
@@ -38,6 +40,11 @@ jobs:
           cache: true
           cache-on-failure: true
           cache-key: "v1-rust-python"
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.17.0
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,10 @@ jobs:
   build-nvim:
     name: Build Neovim ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_IDLE_TIMEOUT: "0"
     permissions:
       contents: read
       id-token: write
@@ -95,6 +99,11 @@ jobs:
         with:
           key: nvim-${{ matrix.target }}
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.17.0
+
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
@@ -150,6 +159,10 @@ jobs:
   build-c:
     name: Build C FFI ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_IDLE_TIMEOUT: "0"
     permissions:
       contents: read
     strategy:
@@ -232,6 +245,11 @@ jobs:
         with:
           key: c-${{ matrix.target }}
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.17.0
+
       - name: Install Zig
         uses: mlugg/setup-zig@v2
         with:
@@ -298,6 +316,10 @@ jobs:
   build-mcp:
     name: Build MCP ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+      SCCACHE_IDLE_TIMEOUT: "0"
     permissions:
       contents: read
     strategy:
@@ -347,6 +369,11 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           key: mcp-${{ matrix.target }}
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.17.0
 
       - name: Install Zig
         uses: mlugg/setup-zig@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,10 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   build-nvim:
     name: Build Neovim ${{ matrix.target }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,8 @@ env:
   # Ensure consistent macOS deployment target across all compiled objects
   # (Rust, cc-compiled C code, and Zig-compiled zlob) to avoid linker warnings
   MACOSX_DEPLOYMENT_TARGET: "13"
+  # RUSTC_WRAPPER is set per job, since cargo fmt runs without sccache.
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   test:
@@ -46,7 +48,14 @@ jobs:
           cache-key: "v1-rust"
           components: rustfmt, clippy
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.17.0
+
       - name: Run tests
+        env:
+          RUSTC_WRAPPER: sccache
         # fff-python requires full python o3 machinery which is very slow
         run: cargo test --no-default-features --features zlob --workspace --exclude fff-nvim --exclude fff-python
 
@@ -66,6 +75,7 @@ jobs:
       FFF_STRESS_CASES: "5"
       FFF_STRESS_MIN_OPS: "30"
       FFF_STRESS_MAX_OPS: "60"
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v5
 
@@ -81,6 +91,11 @@ jobs:
           cache-on-failure: true
           cache-key: "v1-rust-stress-${{ matrix.os }}"
           components: rustfmt, clippy
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.17.0
 
       - name: Stress test seeded
         shell: bash
@@ -125,7 +140,14 @@ jobs:
           cache-on-failure: true
           cache-key: "v1-rust-i686"
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.17.0
+
       - name: Build fff-search for i686
+        env:
+          RUSTC_WRAPPER: sccache
         run: cargo build -p fff-search --target i686-unknown-linux-gnu
 
   fmt:
@@ -158,6 +180,13 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-          
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.11
+        with:
+          version: v0.17.0
+
       - name: Run clippy
+        env:
+          RUSTC_WRAPPER: sccache
         run: cargo clippy --no-default-features --features zlob -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,13 @@ env:
   MACOSX_DEPLOYMENT_TARGET: "13"
   # RUSTC_WRAPPER is set per job, since cargo fmt runs without sccache.
   SCCACHE_GHA_ENABLED: "true"
+  # fff-search alone exceeds the 600s default on windows, and the server sees
+  # no new requests while it compiles, so it would idle out mid-unit.
+  SCCACHE_IDLE_TIMEOUT: "0"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
 jobs:
   test:

--- a/.github/workflows/spelling.yaml
+++ b/.github/workflows/spelling.yaml
@@ -12,6 +12,10 @@ on:
 env:
   CLICOLOR: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   spelling:
     name: Spell Check with Typos

--- a/.github/workflows/stylua.yaml
+++ b/.github/workflows/stylua.yaml
@@ -20,6 +20,10 @@ on:
 env:
   CLICOLOR: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   stylua:
     name: Check lua files using Stylua

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ SMOKE_BIN := $(TARGET_DIR)/fff_c_smoke
 SMOKE_SRC := crates/fff-c/tests/smoke.c
 SMOKE_INCLUDE := crates/fff-c/include
 
-test-c-smoke: build
+test-c-smoke: build-e2e
 	$(CC) $(CFLAGS) -I $(SMOKE_INCLUDE) -L $(TARGET_DIR) \
 		-Wl,-rpath,@loader_path/../target/release \
 		-Wl,-rpath,$$(pwd)/$(TARGET_DIR) \
@@ -136,7 +136,7 @@ test-c-api: test-c-smoke
 # neovim instance swallows internal crashes and doesn't rise the the error exiting silently
 # so check the stdout in case the sigsegv coming out of fff was printed (actual regression).
 # Output is streamed live via `tee`; pipefail (set above) propagates nvim's exit.
-test-lua: test-setup build
+test-lua: test-setup build-e2e
 	@logfile=$$(mktemp); \
 	trap 'rm -f "$$logfile"' EXIT; \
 	nvim --headless -u tests/minimal_init.lua \
@@ -148,7 +148,7 @@ test-lua: test-setup build
 		exit 1; \
 	fi
 
-test-lua-snap: test-setup build
+test-lua-snap: test-setup build-e2e
 	@logfile=$$(mktemp); \
 	trap 'rm -f "$$logfile"' EXIT; \
 	nvim --headless -u tests/minimal_init.lua \
@@ -164,13 +164,13 @@ test-version: test-setup
 	nvim --headless -u tests/minimal_init.lua \
 		-c "PlenaryBustedFile tests/version_spec.lua" 2>&1
 
-prepare-bun: build sync-js-api
+prepare-bun: build-e2e sync-js-api
 	mkdir -p packages/fff-bun/bin
 	cp target/release/libfff_c.dylib packages/fff-bun/bin/ 2>/dev/null || true; \
 	cp target/release/libfff_c.so packages/fff-bun/bin/ 2>/dev/null || true; \
 	cp target/release/fff_c.dll packages/fff-bun/bin/ 2>/dev/null || true
 
-prepare-node: build sync-js-api
+prepare-node: build-e2e sync-js-api
 	mkdir -p packages/fff-node/bin
 	cp target/release/libfff_c.dylib packages/fff-node/bin/ 2>/dev/null || true; \
 	cp target/release/libfff_c.so packages/fff-node/bin/ 2>/dev/null || true; \

--- a/crates/fff-core/Cargo.toml
+++ b/crates/fff-core/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [lib]
 path = "src/lib.rs"
-crate-type = ["rlib", "staticlib", "cdylib"]
+crate-type = ["rlib"]
 
 [[bench]]
 name = "parse_bench"

--- a/tests/programmatic_search_spec.lua
+++ b/tests/programmatic_search_spec.lua
@@ -218,7 +218,13 @@ describe('programmatic search APIs', function()
       local before = fff.content_search(marker)
       assert.are.equal(0, #before.items, 'marker leaked into primary fff tree')
 
-      local result = fff.content_search(marker, { cwd = sandbox_root })
+      -- Poll instead of asserting on the first grep: the index of the new root
+      -- can lag a mkdir by a few ms on CI, which flaked on linux too.
+      local result
+      vim.wait(2000, function()
+        result = fff.content_search(marker, { cwd = sandbox_root })
+        return #result.items > 0
+      end, 50)
       assert.is_true(#result.items > 0, 'cwd switch did not surface match from the new root')
     end)
   end)


### PR DESCRIPTION
Measured on this branch against baseline commit `232288c`. Every test that ran before still runs — verified by diffing test output, not by trusting the timings.

## Results

| job | before | after |
|---|---|---|
| e2e (windows) | 50m05s | **13m46s** |
| e2e (ubuntu) | 27m31s | **8m21s** |
| e2e (macos) | 25m26s | **6m25s** |
| e2e (alpine-musl) | 16m26s | 12m19s |
| Python (windows) | 22m46s | 16m33s |
| Python (ubuntu) | 10m48s | **4m29s** |
| Python (macos) | 10m33s | 6m44s |
| Rust Test (windows) | 11m16s | 7m47s |
| Rust Fuzz (ubuntu) | 8m14s | 3m23s |
| cargo clippy | 2m08s | 1m39s |
| Build i686 | 1m14s | 0m49s |

## 1. The workspace was built two to three times per e2e job

Windows e2e of run [31917764521](https://github.com/dmtrKovalenko/fff/actions/runs/31917764521): `Build Rust binary` 19m47s, then `Run Lua tests` 23m13s, then `Run node tests` 3m32s — three full builds.

`test-lua`, `test-c-smoke`, `prepare-bun` and `prepare-node` all listed `build` (full workspace) as a prerequisite, so the `build-e2e` step added in #782 was never a replacement — it prepended a 20 minute build that was then thrown away.

It's a full rebuild rather than incremental because **cargo resolves features per invocation**: `fff-nvim` enables `fff/mimalloc-collect`, so a different `-p` set re-resolves `fff-search` and everything downstream. Measured: after building the e2e set, `cargo check -p fff-c` re-checks 29 crates.

Every e2e entry point now shares the one `build-e2e` invocation. `build-c-lib` stays for `install`/packagers.

This is also why `Run Lua tests` looks like it dropped from ~200s to 8s: that step was never test time, it was the redundant cargo build. Test output is identical before and after — 59 `Success`, 7 spec files, 0 failures on Windows.

## 2. sccache, stored in the Actions cache

`rust-cache` sets `cache-workspace-crates: false`, so our own crates are never cached. And cargo judges path-dep freshness by **mtime**, which `actions/checkout` rewrites every run, so an unchanged `fff-search` always rebuilt. sccache keys on preprocessed source + flags instead.

On its own it did nothing:

| config | wall time | Rust hits |
|---|---|---|
| sccache cold | 4m44s | 0 / 139 |
| sccache warm | 4m43s | 138 / 139 |
| sccache warm + `fff-core` rlib only | **1m34s** | 139 / 139 |

99.4% hit rate, zero gain — sccache reports `not_cached: {"crate-type": 37}`, refusing any crate type other than rlib. That covered `fff-search`, which cargo timings show is a single 194s unit, 68% of the critical path.

### Why dropping fff-core's staticlib/cdylib is safe

Those artifacts export nothing:

- `fff-c` has all **90** `no_mangle` exports and owns the cbindgen header (`make header` → `--crate fff-c`). `fff-core` has **0** `extern "C"`/`no_mangle`, and its declared `ffi = []` feature is referenced nowhere in the source.
- `nm -D --defined-only libfff_search.so` → **0 dynamic symbols**.
- `libfff_search.a`'s only unmangled globals are compiler intrinsics (`__absvdi2`, `__addvdi3`, …). Zero `fff_`-prefixed exports.
- Nothing in the repo references either artifact — not the release workflow, Makefile, install scripts, or nix.

You cannot link a C program against either and resolve a symbol. The published rlib that Rust consumers use is unchanged. It also drops an 88MB `.a` from every build.

## 3. sccache was killing itself mid-compile on Windows

First CI attempt failed: `error reading compile response from server / An existing connection was forcibly closed`. `fff-search` started at 03:31:54 and died at 03:42:05 — **611s**, against sccache's 600s default `SCCACHE_IDLE_TIMEOUT`. It is the last unit in flight, so no new requests arrive while it compiles and the server idles out mid-unit. Set to `0`.

## 4. Superseded runs were never cancelled

No workflow had a `concurrency` group, and `release.yaml` triggers on `pull_request` with no filter, so every push spawned ~30 cross-compile jobs that saturated the runner pool and starved the test jobs — macOS e2e sat queued for 50 minutes. Added per-workflow concurrency with `cancel-in-progress` for everything except `main` and tags, so release publishing is never interrupted.

## 5. A pre-existing flake

`content_search switches indexed root before grepping` failed on ubuntu with identical code that passed twice before. The index of a freshly created root can lag a `mkdir` — the test already had a Windows-only 250ms sleep for exactly this. Replaced the final assertion with a bounded poll (`vim.wait`, 2s cap, 50ms interval). The assertion is unchanged, it just lets the index catch up. A flake costs a full re-run, which is the most expensive thing in CI.

## Verification

- All four e2e entry points emit one identical `cargo build`; the second is a 0.07s no-op with both `libfff_nvim.so` and `libfff_c.so` present.
- `cargo check --workspace` clean with `fff-core` as rlib only.
- `make test-c-api` passes; `make test-lua` 39/39 locally, 0 failures.
- Windows e2e test output byte-comparable to baseline: 59 `Success`, 7 spec files, 0 failures.
- All jobs green on the latest run.

## Not yet proven

The `release.yaml` sccache change is committed and confirmed active, but its first run was cold and showed no gain (Windows targets still 14-19m). It needs one more run to show whether it pays off; if it doesn't, that commit can be dropped on its own.

Remaining ideas, not done here: `alpine-musl` (12m19s) can't use sccache's GHA backend because container jobs don't get `ACTIONS_RESULTS_URL`/`ACTIONS_RUNTIME_TOKEN` in `run:` steps — it would need a disk-backed cache. And the e2e job could build once and fan the lua/node/bun suites into parallel jobs.

Note: sccache's GHA storage shares the repo's 10GB Actions cache budget and competes with `rust-cache` for eviction.