### PR TITLE
fix(pi-fff): route absolute paths from home

### DIFF
--- a/packages/pi-fff/src/aux-finders.ts
+++ b/packages/pi-fff/src/aux-finders.ts
@@ -169,6 +169,8 @@ export function routePathConstraint(
   if (!pathConstraint) return null;
   let candidate = pathConstraint.trim();
   if (!candidate) return null;
+  const explicitlyRooted =
+    path.isAbsolute(candidate) || candidate === "~" || candidate.startsWith("~/");
   if (candidate === "~" || candidate.startsWith("~/"))
     candidate = path.join(HOME_DIR, candidate.slice(1));
   if (!path.isAbsolute(candidate)) {
@@ -177,7 +179,12 @@ export function routePathConstraint(
     candidate = path.resolve(cwd, candidate);
   }
   const rel = path.relative(cwd, candidate);
-  if (!isOutsideWorkspaceRelativePath(rel)) return null;
+  if (rel === "") return null;
+  if (
+    !isOutsideWorkspaceRelativePath(rel) &&
+    !(explicitlyRooted && path.resolve(cwd) === path.resolve(HOME_DIR))
+  )
+    return null;
   return resolveAuxRoot(candidate);
 }
 

--- a/packages/pi-fff/test/aux-finders.test.ts
+++ b/packages/pi-fff/test/aux-finders.test.ts
@@ -20,8 +20,20 @@ describe("routePathConstraint", () => {
     expect(routePathConstraint("..foo/bar", cwd)).toBeNull();
   });
 
-  test("returns null for absolute paths inside the workspace", () => {
+  test("returns null for absolute paths inside a project workspace", () => {
     expect(routePathConstraint("/tmp/workspace/src", cwd)).toBeNull();
+  });
+
+  test("routes explicit paths under home when home is the workspace", () => {
+    const target = fs.mkdtempSync(path.join(os.homedir(), ".fff-route-"));
+    try {
+      expect(routePathConstraint(target, os.homedir())).toEqual({
+        root: target,
+        suffix: "",
+      });
+    } finally {
+      fs.rmSync(target, { recursive: true, force: true });
+    }
   });
 
   test("routes absolute paths outside the workspace", () => {


### PR DESCRIPTION
## What changed

- Route explicit absolute and `~/` path constraints through a bounded auxiliary index when Pi's workspace is `$HOME`.
- Keep relative paths and absolute paths inside ordinary project workspaces on the primary finder.

## Why

A broad home index can omit nested repositories or ignored paths, so an explicit absolute target can otherwise fail to resolve.

## Validation

- `bun run typecheck`
- `bun test test/aux-finders.test.ts test/query.test.ts` (32 passed)
