### PR TITLE
fix(fff-mcp): answer pre-initialize probes instead of exiting (#797)

### DIFF
--- a/crates/fff-mcp/src/handshake.rs
+++ b/crates/fff-mcp/src/handshake.rs
@@ -1,0 +1,184 @@
+use rmcp::model::{ClientRequest, ErrorCode, ErrorData, JsonRpcMessage};
+use rmcp::service::{RoleServer, RxJsonRpcMessage, TxJsonRpcMessage};
+use rmcp::transport::Transport;
+
+/// rmcp aborts startup on any pre-`initialize` request except `ping`, which kills the process
+/// before the client can retry. Answer such probes with `-32601` and keep waiting for the legacy
+/// handshake, so clients speaking the stateless spec (`server/discover`, SEP-1442) can fall back.
+/// @see https://github.com/dmtrKovalenko/fff/issues/797
+pub(crate) struct ProbeTolerantTransport<T> {
+    inner: T,
+    initialized: bool,
+}
+
+impl<T> ProbeTolerantTransport<T> {
+    pub(crate) fn new(inner: T) -> Self {
+        Self {
+            inner,
+            initialized: false,
+        }
+    }
+}
+
+impl<T> Transport<RoleServer> for ProbeTolerantTransport<T>
+where
+    T: Transport<RoleServer>,
+{
+    type Error = T::Error;
+
+    fn send(
+        &mut self,
+        item: TxJsonRpcMessage<RoleServer>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        self.inner.send(item)
+    }
+
+    async fn receive(&mut self) -> Option<RxJsonRpcMessage<RoleServer>> {
+        loop {
+            let msg = self.inner.receive().await?;
+            if self.initialized {
+                return Some(msg);
+            }
+
+            let JsonRpcMessage::Request(request) = &msg else {
+                return Some(msg);
+            };
+
+            match &request.request {
+                ClientRequest::InitializeRequest(_) => {
+                    self.initialized = true;
+                    return Some(msg);
+                }
+                // rmcp answers pre-init pings itself
+                ClientRequest::PingRequest(_) => return Some(msg),
+                unsupported => {
+                    let error = unsupported_probe_error(unsupported.method());
+                    tracing::warn!(
+                        method = unsupported.method(),
+                        "rejecting pre-initialize request, awaiting initialize"
+                    );
+                    let id = request.id.clone();
+                    self.inner
+                        .send(JsonRpcMessage::error(error, Some(id)))
+                        .await
+                        .ok()?;
+                }
+            }
+        }
+    }
+
+    fn close(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.inner.close()
+    }
+}
+
+fn unsupported_probe_error(method: &str) -> ErrorData {
+    ErrorData::new(
+        ErrorCode::METHOD_NOT_FOUND,
+        format!(
+            "{method} is not supported before initialize; this server uses the initialize handshake"
+        ),
+        None,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::{
+        ClientCapabilities, ClientJsonRpcMessage, CustomRequest, Implementation, InitializeRequest,
+        InitializeRequestParams, NumberOrString, ServerJsonRpcMessage,
+    };
+    use std::collections::VecDeque;
+
+    #[derive(Default)]
+    struct MockTransport {
+        incoming: VecDeque<ClientJsonRpcMessage>,
+        sent: Vec<ServerJsonRpcMessage>,
+    }
+
+    impl Transport<RoleServer> for MockTransport {
+        type Error = std::io::Error;
+
+        fn send(
+            &mut self,
+            item: ServerJsonRpcMessage,
+        ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+            self.sent.push(item);
+            async { Ok(()) }
+        }
+
+        fn receive(&mut self) -> impl Future<Output = Option<ClientJsonRpcMessage>> + Send {
+            let next = self.incoming.pop_front();
+            async move { next }
+        }
+
+        async fn close(&mut self) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    fn custom_request(id: i64, method: &str) -> ClientJsonRpcMessage {
+        ClientJsonRpcMessage::request(
+            ClientRequest::CustomRequest(CustomRequest::new(method, Some(serde_json::json!({})))),
+            NumberOrString::Number(id),
+        )
+    }
+
+    fn initialize_request(id: i64) -> ClientJsonRpcMessage {
+        ClientJsonRpcMessage::request(
+            ClientRequest::InitializeRequest(InitializeRequest::new(InitializeRequestParams::new(
+                ClientCapabilities::default(),
+                Implementation::new("probe", "1"),
+            ))),
+            NumberOrString::Number(id),
+        )
+    }
+
+    #[tokio::test]
+    async fn pre_init_probe_is_rejected_and_initialize_still_arrives() {
+        let inner = MockTransport {
+            incoming: VecDeque::from(vec![
+                custom_request(1, "server/discover"),
+                initialize_request(2),
+            ]),
+            sent: Vec::new(),
+        };
+        let mut transport = ProbeTolerantTransport::new(inner);
+
+        let received = transport.receive().await.expect("initialize forwarded");
+        assert!(matches!(
+            received,
+            JsonRpcMessage::Request(req)
+                if matches!(req.request, ClientRequest::InitializeRequest(_))
+        ));
+
+        let JsonRpcMessage::Error(err) = &transport.inner.sent[0] else {
+            panic!("expected an error response for the probe");
+        };
+        assert_eq!(err.id, Some(NumberOrString::Number(1)));
+        assert_eq!(err.error.code, ErrorCode::METHOD_NOT_FOUND);
+        assert!(err.error.message.contains("server/discover"));
+    }
+
+    #[tokio::test]
+    async fn post_init_requests_pass_through_untouched() {
+        let inner = MockTransport {
+            incoming: VecDeque::from(vec![
+                initialize_request(1),
+                custom_request(2, "server/discover"),
+            ]),
+            sent: Vec::new(),
+        };
+        let mut transport = ProbeTolerantTransport::new(inner);
+
+        transport.receive().await.expect("initialize forwarded");
+        let received = transport.receive().await.expect("custom request forwarded");
+        assert!(matches!(
+            received,
+            JsonRpcMessage::Request(req)
+                if matches!(req.request, ClientRequest::CustomRequest(_))
+        ));
+        assert!(transport.inner.sent.is_empty());
+    }
+}

--- a/crates/fff-mcp/src/main.rs
+++ b/crates/fff-mcp/src/main.rs
@@ -1,4 +1,5 @@
 mod cursor;
+mod handshake;
 mod healthcheck;
 mod output;
 mod parent;
@@ -12,8 +13,10 @@ use fff::file_picker::FilePicker;
 use fff::frecency::FrecencyTracker;
 use fff::{FFFMode, SharedFilePicker, SharedFrecency};
 use git2::Repository;
+use handshake::ProbeTolerantTransport;
 use mimalloc::MiMalloc;
-use rmcp::{ServiceExt, transport::stdio};
+use rmcp::ServiceExt;
+use rmcp::transport::async_rw::AsyncRwTransport;
 use server::FffServer;
 
 #[global_allocator]
@@ -340,7 +343,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     const STARTUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
-    let service = match tokio::time::timeout(STARTUP_TIMEOUT, server.serve(stdio())).await {
+    let stdio = AsyncRwTransport::new_server(tokio::io::stdin(), tokio::io::stdout());
+    let transport = ProbeTolerantTransport::new(stdio);
+    let service = match tokio::time::timeout(STARTUP_TIMEOUT, server.serve(transport)).await {
         Ok(res) => res.map_err(|e| format!("Failed to start MCP server: {}", e))?,
         Err(_) => {
             return Err("MCP initialize handshake did not complete within 60s".into());


### PR DESCRIPTION
Closes #797

## Root cause

Not Antigravity-specific. `rmcp` 1.7.0 (`service/server.rs:169-198`) accepts only `ping` before `initialize`; **any** other pre-init request returns `ExpectedInitializeRequest`, which `crates/fff-mcp/src/main.rs:343` turns into a hard startup error, exit code 1. A client that probes with `server/discover` therefore never gets a response and never gets a chance to fall back to the legacy handshake.

## Fix

New `crates/fff-mcp/src/handshake.rs`: `ProbeTolerantTransport` wraps the stdio transport and, while still uninitialized, answers unsupported requests with `-32601` and keeps reading instead of tearing down the connection. `initialize`, `ping`, notifications, and everything post-init pass through untouched — zero added work on the hot path (one `bool` check, and only until `initialize` arrives).

Scope note @dmtrKovalenko: this implements only the graceful-fallback half of the reporter's ask. Actually serving `server/discover` means implementing the SEP-1442 stateless flow, which is a new protocol mode and needs your scoping — `rmcp` 1.7.0 has no support for it (it decodes the method as `CustomRequest`).

## Steps to reproduce

On pre-fix `origin/main`:

```sh
cargo build -p fff-mcp
mkdir -p /tmp/fff-repro-797

# 1. discover probe alone
printf '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}\n' \
  | ./target/debug/fff-mcp --no-update-check /tmp/fff-repro-797; echo "EXIT=$?"

# 2. discover probe followed immediately by a valid initialize
{ printf '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}\n'
  printf '{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}\n'
  printf '{"jsonrpc":"2.0","method":"notifications/initialized"}\n'
  printf '{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}\n'
  sleep 3; } | ./target/debug/fff-mcp --no-update-check /tmp/fff-repro-797; echo "EXIT=$?"
```

Expected: JSON-RPC error for the unknown method, server stays up, handshake completes, tools listed.

Actual on `main` — both cases exit 1 with nothing on stdout:

```
Error: "Failed to start MCP server: expect initialized request, but received: Some(Request(JsonRpcRequest { jsonrpc: JsonRpcVersion2_0, id: Number(1), request: CustomRequest(CustomRequest { method: \"server/discover\", params: Some(Object {}), extensions: Extensions }) }))"
```

## How verified

`cargo test -p fff-mcp` — 17 unit + 2 integration tests pass, including two new ones in `handshake.rs` (`pre_init_probe_is_rejected_and_initialize_still_arrives`, `post_init_requests_pass_through_untouched`).

`cargo clippy -p fff-mcp --all-targets` and `cargo fmt --check -p fff-mcp` — clean.

Repro case 2 above, post-fix:

```
id 1 ERROR -32601
id 2 result keys: ['capabilities', 'instructions', 'protocolVersion', 'serverInfo']
id 3 tools: ['find_files', 'grep', 'multi_grep']
EXIT=0
```

Regressions checked, all still `ok`: legacy `initialize` + `notifications/initialized` + `tools/call find_files`; pre-init `ping` followed by `initialize` (still answered by rmcp, not intercepted).

Not verified on Windows / real Antigravity CLI 1.1.14 — no such client here. Whether Antigravity actually retries with the legacy handshake after `-32601` is on @Divyesh172 to confirm.

Automated triage via Gustav. Honk-Honk 🪿


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup compatibility by tolerating early connection probes before initialization.
  * Unsupported pre-initialization requests now receive clear errors while the server continues waiting for initialization.
  * Initialization and ping requests are handled normally, with subsequent communication passed through unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->