### PR TITLE
fix(core): recompute basename offset after lossy path decode (#799)

### DIFF
--- a/crates/fff-core/src/file_picker.rs
+++ b/crates/fff-core/src/file_picker.rs
@@ -504,9 +504,7 @@ impl FileItem {
         modified: u64,
     ) -> (Self, String) {
         let is_binary = is_known_binary_extension(path);
-        // SAFETY-ish: paths on macOS/Linux are bytes; lossy conversion mirrors
-        // the existing `to_string_lossy()` behavior on non-UTF8 names.
-        let rel_str = String::from_utf8_lossy(relative_path).into_owned();
+        let (rel_str, basename_offset) = decode_walk_rel_path(relative_path, basename_offset);
         let item = Self::new_raw(basename_offset, size, modified, git_status, is_binary);
         (item, rel_str)
     }
@@ -2262,6 +2260,21 @@ fn push_dir_item(
     dirs.push(DirItem::new(dir_string, last_seg));
 }
 
+/// Decodes raw walker path bytes into the index's UTF-8 form, returning the
+/// basename offset valid for that string. Lossy decoding rewrites invalid
+/// bytes as 3-byte U+FFFD, so a raw-byte offset can land mid-char; recompute
+/// it in that (cold) case. Valid UTF-8 keeps the walker's offset for free.
+#[inline]
+pub(crate) fn decode_walk_rel_path(relative_path: &[u8], basename_offset: u16) -> (String, u16) {
+    match String::from_utf8_lossy(relative_path) {
+        std::borrow::Cow::Borrowed(valid) => (valid.to_owned(), basename_offset),
+        std::borrow::Cow::Owned(lossy) => {
+            let offset = lossy.rfind(std::path::is_separator).map_or(0, |i| i + 1) as u16;
+            (lossy, offset)
+        }
+    }
+}
+
 /// Fast extension-based binary detection. Avoids opening files during scan.
 /// Covers the vast majority of binary files in typical repositories.
 #[inline]
@@ -2558,6 +2571,31 @@ mod tests {
                 "file {rel} must live under its parent dir",
             );
         }
+    }
+
+    /// Walkers hand out raw path bytes plus a basename offset measured on
+    /// those bytes. Invalid UTF-8 becomes a 3-byte U+FFFD, so the offset must
+    /// be recomputed on the decoded string or every slice at it panics.
+    #[test]
+    fn dir_table_handles_invalid_utf8_dir_names() {
+        let raw: &[u8] = b"\xff\xffx/file.txt";
+        let raw_offset = raw.iter().position(|b| *b == b'/').unwrap() as u16 + 1;
+        let (item, rel) =
+            FileItem::new_from_walk_bytes(Path::new("file.txt"), raw, raw_offset, None, 0, 0);
+
+        assert_eq!(rel, "\u{FFFD}\u{FFFD}x/file.txt");
+        assert!(rel.is_char_boundary(item.path.filename_offset as usize));
+        assert_eq!(&rel[item.path.filename_offset as usize..], "file.txt");
+
+        let mut pairs = vec![(item, rel)];
+        let walked = vec!["\u{FFFD}\u{FFFD}x/".to_string()];
+        let mut builder = crate::simd_path::ChunkedPathStoreBuilder::new(pairs.len());
+        let dirs = populates_dirs_files_chunked_storage(&mut pairs, &walked, &mut builder);
+        let store = builder.finish();
+        let arena = store.as_arena_ptr();
+
+        let table: Vec<String> = dirs.iter().map(|d| d.relative_path(arena)).collect();
+        assert_eq!(table, ["\u{FFFD}\u{FFFD}x/"]);
     }
 
     #[test]

--- a/crates/fff-core/src/walk/zlob.rs
+++ b/crates/fff-core/src/walk/zlob.rs
@@ -78,10 +78,12 @@ pub(crate) fn walk_collect_files(
             .map(|ns| (ns / 1_000_000_000).max(0) as u64)
             .unwrap_or(0);
 
-        let basename_offset = entry.basename_offset_in_relative();
         // zlob emits '/'-separated relative paths, which is fff's canonical
         // internal form on every platform — store them verbatim.
-        let rel_str = String::from_utf8_lossy(rel_bytes).into_owned();
+        let (rel_str, basename_offset) = crate::file_picker::decode_walk_rel_path(
+            rel_bytes,
+            entry.basename_offset_in_relative(),
+        );
         let item = FileItem::new_raw(basename_offset, size, modified, None, is_binary);
 
         let mut guard = collected.lock();


### PR DESCRIPTION
Closes #799

## Root cause

`crates/fff-core/src/walk/zlob.rs:81-83` paired `entry.basename_offset_in_relative()` — measured on the **raw** path bytes — with `String::from_utf8_lossy(rel_bytes)`. Lossy decoding expands each invalid byte into a 3-byte U+FFFD, shifting the real separator forward, so the stored `filename_offset` can land inside a replacement char. `crates/fff-core/src/file_picker.rs:2205` then slices at it (`&rel[..filename_offset]`) and panics on the Rayon scan thread, which aborts the process. `FileItem::new_from_walk_bytes` (`file_picker.rs:498`) had the same defect. zlob-only: release/npm artifacts build `--features zlob`; the ripgrep backend derives the offset from the decoded string via `new_from_walk_parts` and is unaffected.

## Fix

New `decode_walk_rel_path()` helper decodes the bytes once and only recomputes the offset when the decode was actually lossy (`Cow::Owned`). Valid UTF-8 — every real-world path — takes the `Cow::Borrowed` arm and keeps the walker's offset, so the hot scan path is byte-for-byte the same work as before.

## Steps to reproduce

`\xff\xff` in a directory name cannot be created on APFS (`EILSEQ`), so the deterministic repro drives the exact walker output shape directly. On pre-fix `main`, add to `mod tests` in `crates/fff-core/src/file_picker.rs`:

```rust
#[test]
fn repro_799() {
    let raw: &[u8] = b"\xff\xffx/file.txt"; // separator at byte 3 -> zlob basename_offset = 4
    let (item, rel) = FileItem::new_from_walk_bytes(Path::new("file.txt"), raw, 4, None, 0, 0);
    let mut pairs = vec![(item, rel)];
    let walked = vec!["\u{FFFD}\u{FFFD}x/".to_string()];
    let mut builder = crate::simd_path::ChunkedPathStoreBuilder::new(1);
    let dirs = populates_dirs_files_chunked_storage(&mut pairs, &walked, &mut builder);
    let store = builder.finish();
    let arena = store.as_arena_ptr();
    let table: Vec<String> = dirs.iter().map(|d| d.relative_path(arena)).collect();
    assert_eq!(table, ["\u{FFFD}\u{FFFD}x/"]);
}
```

```sh
cargo test -p fff-search --no-default-features --features zlob --lib repro_799
```

Expected: `test result: ok`, dir table `["\u{FFFD}\u{FFFD}x/"]`, basename `file.txt`.

Actual on pre-fix `main`:

```text
thread 'file_picker::tests::repro_799' panicked at crates/fff-core/src/file_picker.rs:2205:37:
byte index 4 is not a char boundary; it is inside '\u{fffd}' (bytes 3..6) of `\u{fffd}\u{fffd}x/file.txt`
```

Full end-to-end variant on Linux/ext4 (matches the reporter's tarball):

```sh
python3 -c 'import os; d=b"/tmp/fff-repro/\xff\xffx"; os.makedirs(d, exist_ok=True); open(d+b"/file.txt","wb").close()'
# then FileFinder.create({ basePath: "/tmp/fff-repro" }) + waitForScan
# pre-fix: "Rayon: detected unexpected panic; aborting"
```

## How verified

```sh
cargo test --workspace --no-default-features --features zlob --exclude fff-nvim --exclude fff-python
# all 30 test binaries ok, 0 failed (includes the new dir_table_handles_invalid_utf8_dir_names)
cargo clippy --workspace --no-default-features --features zlob -- -D warnings   # clean
cargo check -p fff-search                                                       # ripgrep backend, clean
cargo fmt --all                                                                 # no diff
```

Regression test `dir_table_handles_invalid_utf8_dir_names` (`crates/fff-core/src/file_picker.rs`) fails with the char-boundary panic when the fix is reverted, passes with it.

Automated triage via Gustav. Honk-Honk 🪿


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of files and directories with invalid UTF-8 characters in their names.
  * Preserved correct filename boundaries when displaying paths containing unusual characters.
  * Added regression coverage to ensure directory listings are built correctly for these paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->