### PR TITLE
fix(fff-search): keep filename_offset on a char boundary for non-UTF-8 names

### DIFF
--- a/crates/fff-core/src/file_picker.rs
+++ b/crates/fff-core/src/file_picker.rs
@@ -504,11 +504,17 @@ impl FileItem {
         modified: u64,
     ) -> (Self, String) {
         let is_binary = is_known_binary_extension(path);
-        // SAFETY-ish: paths on macOS/Linux are bytes; lossy conversion mirrors
-        // the existing `to_string_lossy()` behavior on non-UTF8 names.
-        let rel_str = String::from_utf8_lossy(relative_path).into_owned();
-        let item = Self::new_raw(basename_offset, size, modified, git_status, is_binary);
-        (item, rel_str)
+        // basename_offset indexes the raw bytes; from_utf8_lossy keeps those
+        // indices only for valid UTF-8, so re-derive when a byte was replaced (#799).
+        let rel = String::from_utf8_lossy(relative_path);
+        let fname_offset = match &rel {
+            std::borrow::Cow::Borrowed(_) => basename_offset,
+            std::borrow::Cow::Owned(s) => {
+                s.rfind(std::path::is_separator).map_or(0, |i| i + 1) as u16
+            }
+        };
+        let item = Self::new_raw(fname_offset, size, modified, git_status, is_binary);
+        (item, rel.into_owned())
     }
 
     pub(crate) fn update_frecency_scores(
@@ -2394,6 +2400,17 @@ pub(crate) fn hint_allocator_collect() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn walk_bytes_offset_stays_on_a_char_boundary_for_non_utf8_names() {
+        // 0xFF becomes a 3-byte U+FFFD, so the raw basename_offset (2, past
+        // "\xff/") would slice inside it; the split must stay on a boundary (#799).
+        let (item, rel) =
+            FileItem::new_from_walk_bytes(Path::new("x.txt"), b"\xff/.txt", 2, None, 0, 0);
+        let (dir, file) = rel.split_at(item.path.filename_offset as usize);
+        assert_eq!(dir, "\u{fffd}/");
+        assert_eq!(file, ".txt");
+    }
 
     /// The watcher must watch every ancestor directory up to `base_path`,
     /// not just the immediate parents of indexed files. The dir table is


### PR DESCRIPTION
Fixes #799.

## The crash

Scanning a directory that contains a filename with invalid UTF-8 bytes aborts the process from the Rayon scan thread:

```
thread 'fff-bg-0' panicked at crates/fff-core/src/file_picker.rs:2207:
end byte index N is not a char boundary; it is inside '\u{fffd}'
Rayon: detected unexpected panic; aborting
```

## Root cause

`FileItem::new_from_walk_bytes` (the zlob walker fast path) is handed a `basename_offset` that indexes the **raw** path bytes, and stores it as the `filename_offset` into a `String` built with `String::from_utf8_lossy(relative_path)`.

`from_utf8_lossy` replaces each ill-formed byte with a 3-byte `U+FFFD`, so on a non-UTF-8 name every index past the first bad byte shifts. The stored offset can then point **inside** a replacement char, and the later `&rel[..filename_offset]` slice (and the `split_at` at line 2207) panics on the non-boundary index. The `SAFETY: filename_offset is always at a character boundary` note a few lines up does not hold for this path.

The pure-Rust walker path (`new_from_walk`) is unaffected because it derives the offset from the lossy string itself via `rfind(is_separator)`.

## The fix

Re-derive the split from the lossy string when a byte was actually replaced (`Cow::Owned`), the same way the walker path does. Valid UTF-8 is the overwhelming common case and stays on the fast path: `from_utf8_lossy` borrows, so the raw `basename_offset` is used unchanged with no `rfind`.

```rust
let rel = String::from_utf8_lossy(relative_path);
let fname_offset = match &rel {
    std::borrow::Cow::Borrowed(_) => basename_offset,
    std::borrow::Cow::Owned(s) => s.rfind(std::path::is_separator).map_or(0, |i| i + 1) as u16,
};
```

## Verification (Windows, default `ripgrep` features)

- New unit test `walk_bytes_offset_stays_on_a_char_boundary_for_non_utf8_names`: feeds `b"\xff/.txt"` with the raw `basename_offset` (2) that used to slice inside the `U+FFFD`, and asserts the split lands on a boundary (`"\u{fffd}/"` + `".txt"`). It panics on `main`, passes here.
- `cargo test -p fff-search --lib` — 160 passed, 0 failed.
- `cargo fmt --all -- --check` — clean.

The test drives `new_from_walk_bytes` directly, so it exercises the fix under either glob backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where filenames containing invalid UTF-8 characters could be split incorrectly in the file picker.
  * Directory and file paths are now identified correctly even when filenames contain unusual characters.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->