### PR TITLE
fix(pi-fff): allow muting the $HOME scan warning (#806)

### DIFF
--- a/packages/pi-fff/README.md
+++ b/packages/pi-fff/README.md
@@ -171,7 +171,7 @@ The file is global only. Project-level config cannot safely control tool names b
 - `--fff-history-db <path>` — path to query history database (also: `FFF_HISTORY_DB` env). Optional; see [Data](#data) for the default.
 - `--fff-enable-root-scan` — allow indexing when launched from `/` (also: `FFF_ENABLE_ROOT_SCAN=1` env). FFF refuses to init at the filesystem root by default.
 - `--fff-enable-home-scan` — index the home directory when launched from `$HOME` (also: `FFF_ENABLE_HOME_SCAN` env). Enabled by default. Disable with `--fff-enable-home-scan=false` or `FFF_ENABLE_HOME_SCAN=0` if your `$HOME` contains huge trees (toolchains, kernel sources, build outputs) that make the background index run for a long time. When launched from `$HOME` with this enabled, pi shows a warning that the whole home tree is being indexed.
-- `--fff-warn-home-scan` — show the warning notification when `$HOME` is indexed (also: `FFF_WARN_HOME_SCAN` env). Enabled by default. Set `--fff-warn-home-scan=false` or `FFF_WARN_HOME_SCAN=0` if indexing `$HOME` is intentional and the notification is just noise. The live indexing status in the footer is unaffected.
+- `--fff-warn-home-scan` — show the warning notification when `$HOME` is indexed (also: `FFF_WARN_HOME_SCAN` env). Enabled by default. Set `--fff-warn-home-scan=false`, `FFF_WARN_HOME_SCAN=0`, or `"warnOnHomeDirScan": false` in `pi-fff.json` if indexing `$HOME` is intentional and the notification is just noise. The live indexing status in the footer is unaffected.
 
 ## Data
 

--- a/packages/pi-fff/README.md
+++ b/packages/pi-fff/README.md
@@ -171,7 +171,7 @@ The file is global only. Project-level config cannot safely control tool names b
 - `--fff-history-db <path>` — path to query history database (also: `FFF_HISTORY_DB` env). Optional; see [Data](#data) for the default.
 - `--fff-enable-root-scan` — allow indexing when launched from `/` (also: `FFF_ENABLE_ROOT_SCAN=1` env). FFF refuses to init at the filesystem root by default.
 - `--fff-enable-home-scan` — index the home directory when launched from `$HOME` (also: `FFF_ENABLE_HOME_SCAN` env). Enabled by default. Disable with `--fff-enable-home-scan=false` or `FFF_ENABLE_HOME_SCAN=0` if your `$HOME` contains huge trees (toolchains, kernel sources, build outputs) that make the background index run for a long time. When launched from `$HOME` with this enabled, pi shows a warning that the whole home tree is being indexed.
-- `--fff-warn-home-scan` — show the warning notification when `$HOME` is indexed (also: `FFF_WARN_HOME_SCAN` env). Enabled by default. Set `--fff-warn-home-scan=false`, `FFF_WARN_HOME_SCAN=0`, or `"warnOnHomeDirScan": false` in `pi-fff.json` if indexing `$HOME` is intentional and the notification is just noise. The live indexing status in the footer is unaffected.
+- `--fff-warn-home-scan` — show the warning notification when `$HOME` is indexed (also: `FFF_WARN_HOME_SCAN` env). Enabled by default. Disable with `--fff-warn-home-scan=false`, `FFF_WARN_HOME_SCAN=0`, or `"warnOnHomeDirScan": false` in `pi-fff.json`. Indexing and the footer status are unaffected.
 
 ## Data
 

--- a/packages/pi-fff/README.md
+++ b/packages/pi-fff/README.md
@@ -143,7 +143,8 @@ For persistent global configuration, create `pi-fff.json` in pi's agent director
   "frecencyDbPath": "/path/to/frecency",
   "historyDbPath": "/path/to/history",
   "enableFsRootScanning": false,
-  "enableHomeDirScanning": true
+  "enableHomeDirScanning": true,
+  "warnOnHomeDirScan": true
 }
 ```
 
@@ -157,6 +158,7 @@ All fields are optional:
 | `historyDbPath` | non-empty string | See [Data](#data) |
 | `enableFsRootScanning` | boolean | `false` |
 | `enableHomeDirScanning` | boolean | `true` |
+| `warnOnHomeDirScan` | boolean | `true` |
 
 CLI flags take precedence over environment variables, which take precedence over this file. A missing file is ignored. Malformed JSON, unknown fields, and invalid values stop the extension from loading and report the file path and error. `/fff-mode` changes the current session; it does not edit this file.
 
@@ -169,6 +171,7 @@ The file is global only. Project-level config cannot safely control tool names b
 - `--fff-history-db <path>` — path to query history database (also: `FFF_HISTORY_DB` env). Optional; see [Data](#data) for the default.
 - `--fff-enable-root-scan` — allow indexing when launched from `/` (also: `FFF_ENABLE_ROOT_SCAN=1` env). FFF refuses to init at the filesystem root by default.
 - `--fff-enable-home-scan` — index the home directory when launched from `$HOME` (also: `FFF_ENABLE_HOME_SCAN` env). Enabled by default. Disable with `--fff-enable-home-scan=false` or `FFF_ENABLE_HOME_SCAN=0` if your `$HOME` contains huge trees (toolchains, kernel sources, build outputs) that make the background index run for a long time. When launched from `$HOME` with this enabled, pi shows a warning that the whole home tree is being indexed.
+- `--fff-warn-home-scan` — show the warning notification when `$HOME` is indexed (also: `FFF_WARN_HOME_SCAN` env). Enabled by default. Set `--fff-warn-home-scan=false` or `FFF_WARN_HOME_SCAN=0` if indexing `$HOME` is intentional and the notification is just noise. The live indexing status in the footer is unaffected.
 
 ## Data
 

--- a/packages/pi-fff/pi-fff.schema.json
+++ b/packages/pi-fff/pi-fff.schema.json
@@ -36,6 +36,11 @@
       "type": "boolean",
       "default": true,
       "description": "Allows indexing when pi is launched from the home directory."
+    },
+    "warnOnHomeDirScan": {
+      "type": "boolean",
+      "default": true,
+      "description": "Shows a warning notification when the home directory is indexed."
     }
   }
 }

--- a/packages/pi-fff/src/config.ts
+++ b/packages/pi-fff/src/config.ts
@@ -14,6 +14,7 @@ export interface FffConfig {
   historyDbPath?: string;
   enableFsRootScanning?: boolean;
   enableHomeDirScanning?: boolean;
+  warnOnHomeDirScan?: boolean;
 }
 
 const CONFIG_KEYS = new Set<keyof FffConfig>([
@@ -23,6 +24,7 @@ const CONFIG_KEYS = new Set<keyof FffConfig>([
   "historyDbPath",
   "enableFsRootScanning",
   "enableHomeDirScanning",
+  "warnOnHomeDirScan",
 ]);
 
 export function loadConfig(agentDir = piDataDir()): FffConfig {
@@ -64,6 +66,7 @@ export function loadConfig(agentDir = piDataDir()): FffConfig {
   validateString(configPath, parsed, "historyDbPath");
   validateBoolean(configPath, parsed, "enableFsRootScanning");
   validateBoolean(configPath, parsed, "enableHomeDirScanning");
+  validateBoolean(configPath, parsed, "warnOnHomeDirScan");
 
   return parsed as FffConfig;
 }
@@ -94,7 +97,7 @@ function validateString(
 function validateBoolean(
   configPath: string,
   config: Record<string, unknown>,
-  key: "enableFsRootScanning" | "enableHomeDirScanning",
+  key: "enableFsRootScanning" | "enableHomeDirScanning" | "warnOnHomeDirScan",
 ): void {
   const value = config[key];
   if (value !== undefined && typeof value !== "boolean") {

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -50,7 +50,8 @@ const GREP_TIME_BUDGET_MS = 10_000;
 const HOME_SCAN_STATUS_KEY = "fff";
 const HOME_SCAN_POLL_MS = 1_000;
 const HOME_SCAN_DISABLE_HINT =
-  "You can prevent home dir indexing with --fff-enable-home-scan=false, FFF_ENABLE_HOME_SCAN=0, or enableHomeDirScanning in pi-fff.json.";
+  "You can prevent home dir indexing with --fff-enable-home-scan=false, FFF_ENABLE_HOME_SCAN=0, or enableHomeDirScanning in pi-fff.json. " +
+  "To keep indexing but silence this warning use --fff-warn-home-scan=false, FFF_WARN_HOME_SCAN=0, or warnOnHomeDirScan in pi-fff.json.";
 
 interface ToolNames {
   grep: string;
@@ -343,6 +344,7 @@ export default function fffExtension(pi: ExtensionAPI) {
   let resolvedDbPaths: ReturnType<typeof resolveDbPaths>;
   let enableFsRootScanning = false;
   let enableHomeDirScanning = true;
+  let warnOnHomeDirScan = true;
 
   function setMode(mode: FffMode): void {
     currentMode = mode;
@@ -385,6 +387,15 @@ export default function fffExtension(pi: ExtensionAPI) {
       true,
       parseBoolean,
     );
+    // Users who intentionally index $HOME see the warning on every launch and
+    // can do nothing about it, so let them mute it (issue #806).
+    warnOnHomeDirScan = getConfigValue(
+      "fff-warn-home-scan",
+      "FFF_WARN_HOME_SCAN",
+      config.warnOnHomeDirScan,
+      true,
+      parseBoolean,
+    );
   }
 
   function getMode(): FffMode {
@@ -406,6 +417,7 @@ export default function fffExtension(pi: ExtensionAPI) {
   let homeScanTimer: ReturnType<typeof setInterval> | null = null;
 
   function warnHomeDirScan(root: string): void {
+    if (!warnOnHomeDirScan) return;
     uiCtx?.ui.notify(
       `(fff): Your cwd (${root}) is too large. Indexing will take additional time and resources.\n${HOME_SCAN_DISABLE_HINT}`,
       "warning",
@@ -664,6 +676,12 @@ export default function fffExtension(pi: ExtensionAPI) {
   pi.registerFlag("fff-enable-home-scan", {
     description:
       "Index the home dir when launched from $HOME (default true; disable with --fff-enable-home-scan=false or FFF_ENABLE_HOME_SCAN=0)",
+    type: "boolean",
+  });
+
+  pi.registerFlag("fff-warn-home-scan", {
+    description:
+      "Warn when indexing $HOME (default true; silence with --fff-warn-home-scan=false or FFF_WARN_HOME_SCAN=0)",
     type: "boolean",
   });
 

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -387,8 +387,6 @@ export default function fffExtension(pi: ExtensionAPI) {
       true,
       parseBoolean,
     );
-    // Users who intentionally index $HOME see the warning on every launch and
-    // can do nothing about it, so let them mute it (issue #806).
     warnOnHomeDirScan = getConfigValue(
       "fff-warn-home-scan",
       "FFF_WARN_HOME_SCAN",

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -50,8 +50,8 @@ const GREP_TIME_BUDGET_MS = 10_000;
 const HOME_SCAN_STATUS_KEY = "fff";
 const HOME_SCAN_POLL_MS = 1_000;
 const HOME_SCAN_DISABLE_HINT =
-  "You can prevent home dir indexing with --fff-enable-home-scan=false, FFF_ENABLE_HOME_SCAN=0, or enableHomeDirScanning in pi-fff.json. " +
-  "To keep indexing but silence this warning use --fff-warn-home-scan=false, FFF_WARN_HOME_SCAN=0, or warnOnHomeDirScan in pi-fff.json.";
+  'You can prevent home dir indexing with --fff-enable-home-scan=false, FFF_ENABLE_HOME_SCAN=0, or "enableHomeDirScanning": false in pi-fff.json. ' +
+  'To keep indexing but silence this warning use --fff-warn-home-scan=false, FFF_WARN_HOME_SCAN=0, or "warnOnHomeDirScan": false in pi-fff.json.';
 
 interface ToolNames {
   grep: string;

--- a/packages/pi-fff/test/config.test.ts
+++ b/packages/pi-fff/test/config.test.ts
@@ -31,6 +31,7 @@ describe("loadConfig", () => {
       historyDbPath: "/data/history",
       enableFsRootScanning: true,
       enableHomeDirScanning: false,
+      warnOnHomeDirScan: false,
     };
     writeConfig(config);
 
@@ -66,6 +67,7 @@ describe("loadConfig", () => {
       [{ historyDbPath: false }, '"historyDbPath" must be a non-empty string'],
       [{ enableFsRootScanning: 1 }, '"enableFsRootScanning" must be a boolean'],
       [{ enableHomeDirScanning: "false" }, '"enableHomeDirScanning" must be a boolean'],
+      [{ warnOnHomeDirScan: "false" }, '"warnOnHomeDirScan" must be a boolean'],
     ];
 
     for (const [config, message] of cases) {

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -427,8 +427,7 @@ describe("pi-fff $HOME scan warning", () => {
     await shutdown(setup);
   });
 
-  // #806: indexing $HOME can be intentional, so the warning must be mutable
-  // without turning the scan off. The progress footer stays.
+  // #806: muting the warning must not turn the scan or the footer off.
   test("FFF_WARN_HOME_SCAN=0 mutes the warning but keeps indexing", async () => {
     process.env.FFF_WARN_HOME_SCAN = "0";
     const setup = await start(undefined, os.homedir());

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -190,6 +190,7 @@ const CONFIG_ENV_KEYS = [
   "FFF_HISTORY_DB",
   "FFF_ENABLE_ROOT_SCAN",
   "FFF_ENABLE_HOME_SCAN",
+  "FFF_WARN_HOME_SCAN",
 ] as const;
 
 const savedEnv: Record<string, string | undefined> = {};
@@ -423,6 +424,40 @@ describe("pi-fff $HOME scan warning", () => {
 
     expect(setup.ctx.ui.notify).not.toHaveBeenCalled();
     expect(setup.ctx.ui.setStatus).not.toHaveBeenCalled();
+    await shutdown(setup);
+  });
+
+  // #806: indexing $HOME can be intentional, so the warning must be mutable
+  // without turning the scan off. The progress footer stays.
+  test("FFF_WARN_HOME_SCAN=0 mutes the warning but keeps indexing", async () => {
+    process.env.FFF_WARN_HOME_SCAN = "0";
+    const setup = await start(undefined, os.homedir());
+
+    expect(setup.ctx.ui.notify).not.toHaveBeenCalled();
+    expect(setup.ctx.ui.setStatus).toHaveBeenCalledWith(
+      "fff",
+      "Agent is indexing $HOME, this can lead to high CPU",
+    );
+    expect(
+      (createCalls[0] as { enableHomeDirScanning: boolean }).enableHomeDirScanning,
+    ).toBe(true);
+    await shutdown(setup);
+  });
+
+  test("--fff-warn-home-scan=false mutes the warning", async () => {
+    const setup = await start(undefined, os.homedir(), {
+      "fff-warn-home-scan": false,
+    });
+
+    expect(setup.ctx.ui.notify).not.toHaveBeenCalled();
+    await shutdown(setup);
+  });
+
+  test("warnOnHomeDirScan in the config file mutes the warning", async () => {
+    writeConfig({ warnOnHomeDirScan: false });
+    const setup = await start(undefined, os.homedir());
+
+    expect(setup.ctx.ui.notify).not.toHaveBeenCalled();
     await shutdown(setup);
   });
 });


### PR DESCRIPTION
Closes #806

## Root cause

`warnHomeDirScan` (`packages/pi-fff/src/index.ts:417`) notifies unconditionally. `session_start` calls it whenever cwd is `$HOME` and home scanning is on (`src/index.ts:735`), and so does `AuxFinderPool` via `onHomeDirScan` (`src/aux-finders.ts:100`). The only escape was `enableHomeDirScanning: false`, which kills the indexing the reporter wants to keep.

## Fix

New boolean `warnOnHomeDirScan` (default `true`) resolved through the existing flag > env > file > fallback chain: `--fff-warn-home-scan`, `FFF_WARN_HOME_SCAN`, `warnOnHomeDirScan` in `pi-fff.json`. When false, `warnHomeDirScan` returns early; scanning is untouched. The live footer (`Agent is indexing $HOME...`) is left alone — transient state, not a per-launch warning.

## Steps to reproduce

On pre-fix `main`:

```sh
cd packages && bun install
cd pi-fff && bun test -t "mutes the warning"
```

Expected: pass. Actual: 3 fail — two with `Expected number of calls: 0 / Received number of calls: 1`, one with `unknown option "warnOnHomeDirScan"`.

End-user path — nothing silences the warning while keeping the index:

```sh
cd $HOME
FFF_WARN_HOME_SCAN=0 pi -e <fff>/packages/pi-fff/src/index.ts -p --no-session "hi"
```

Expected: no warning. Actual:

```
(fff): Your cwd (/Users/you) is too large. Indexing will take additional time and resources.
You can prevent home dir indexing with --fff-enable-home-scan=false, FFF_ENABLE_HOME_SCAN=0, or enableHomeDirScanning in pi-fff.json.
```

## How verified

`cd packages/pi-fff && bun test` — 79 pass / 0 fail. Three new tests (env var, CLI flag, config file) each also assert `enableHomeDirScanning` stays `true` and the footer still pins; all three fail with `src/` stashed. `bun lint` and `bun format` clean.

Live smoke from a scratch dir with `-e packages/pi-fff/src/index.ts`: starts, registers the flag, exits 0. Did not run the `cd $HOME` path live — it kicks off a real full-home index; the tests drive the same `session_start` handler with `cwd = os.homedir()`.

`bun run typecheck` fails with `Cannot find module '@ff-labs/fff-node'` — pre-existing, same on `main`.

Automated triage via Gustav. Honk-Honk 🪿


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable warnings when indexing the home directory.
  * Warnings are enabled by default and can be disabled through configuration, the `FFF_WARN_HOME_SCAN` environment variable, or the `--fff-warn-home-scan` command-line option.
  * Added support for configuring this setting in `pi-fff.json`.

* **Documentation**
  * Documented configuration, environment variables, defaults, and disablement options.

* **Bug Fixes**
  * Confirmed that disabling the warning does not prevent home-directory indexing or affect status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->