### PR TITLE
chore(fff-core): use as_chunks in flush_seen (clippy 1.98)

### DIFF
--- a/crates/fff-core/src/index/bigram_filter.rs
+++ b/crates/fff-core/src/index/bigram_filter.rs
@@ -264,7 +264,8 @@ impl BigramIndexBuilder {
     fn flush_seen(&self, seen: &[u64; SEEN_WORDS], word_idx: usize, bit_mask: u64) {
         let col_base = self.col_data_ptr();
         let words = self.words;
-        for (blk, block) in seen.chunks_exact(8).enumerate() {
+        // SEEN_WORDS is a multiple of 8, so the remainder is always empty.
+        for (blk, block) in seen.as_chunks::<8>().0.iter().enumerate() {
             // OR-test whole blocks so the mostly-empty bitmap scans fast.
             if block.iter().fold(0u64, |a, &w| a | w) == 0 {
                 continue;


### PR DESCRIPTION
No issue. Unblocks CI on #807 and every other open PR.

## Root cause

`cargo clippy --no-default-features --features zlob -- -D warnings` fails on `main`:

```
error: using `chunks_exact` with a constant chunk size
   --> crates/fff-core/src/index/bigram_filter.rs:267:34
267 |         for (blk, block) in seen.chunks_exact(8).enumerate() {
    |                                  ^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<8>().0.iter()`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks
error: could not compile `fff-search` (lib) due to 1 previous error
```

`chunks_exact_to_as_chunks` is new in clippy 1.98. Stable rolled to 1.98.0 (88d9e12ae) on 2026-08-18; `rust-toolchain.toml` tracks `channel = "stable"` and the clippy job uses `dtolnay/rust-toolchain@master` with `toolchain: stable`, so every run since the roll fails. The line itself is from a487120 (#676, 2026-07-14) and was clean under 1.92.

## Fix

One line in `flush_seen`: `seen.chunks_exact(8)` -> `seen.as_chunks::<8>().0.iter()`. `SEEN_WORDS = 1024` is a multiple of 8, so the remainder slice is always empty and iteration is unchanged. Block type becomes `&[u64; 8]` instead of `&[u64]`, which gives the vectorizer a static length for the OR-test fold — same or better codegen, no behavior change.

## Steps to reproduce

```sh
git checkout main
rustup toolchain install 1.98.0 --component clippy --profile minimal
cargo +1.98.0 clippy --no-default-features --features zlob -- -D warnings
```

Expected: clean. Actual on `main`: the error above, exit 101. Under `1.92.0` it is clean, which is why nothing caught it earlier.

## How verified

```
cargo +1.98.0 clippy --no-default-features --features zlob -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.51s
```

That is the full CI command and it is the only clippy job; no other 1.98 lint fires on the workspace.

```
cargo test -p fff-search --no-default-features --features zlob --lib
test result: ok. 159 passed; 0 failed
cargo fmt -- --check   # clean
```

Automated triage via Gustav. Honk-Honk 🪿


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved internal processing efficiency when flushing tracked bigrams, with no change to observable search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->