### PR TITLE
fix(nvim): keep prompt cursor at current input end

### DIFF
--- a/lua/fff/picker_ui/picker_ui.lua
+++ b/lua/fff/picker_ui/picker_ui.lua
@@ -666,7 +666,8 @@ local function open_ui_with_state(query, results, location, merged_config, curre
   if query then
     vim.schedule(function()
       if M.state.active and M.state.input_win and vim.api.nvim_win_is_valid(M.state.input_win) then
-        vim.api.nvim_win_set_cursor(M.state.input_win, { 1, #M.state.config.prompt + #query })
+        local line = vim.api.nvim_buf_get_lines(M.state.input_buf, 0, 1, false)[1] or ''
+        vim.api.nvim_win_set_cursor(M.state.input_win, { 1, #line })
         vim.cmd('startinsert!')
       end
     end)


### PR DESCRIPTION
**Problem**
When typing immediately after opening the picker, the prompt cursor could move behind the first character. For example, typing `files` could produce `ilesf`.

The picker scheduled cursor positioning with `vim.schedule()`, but calculated the position using the query captured when the picker opened:
`#config.prompt + #query`

Because the callback runs later, query could be outdated by the time it executed.

**Fix**
Read the current prompt line inside the scheduled callback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor placement for prefilled picker queries by positioning it at the end of the current input text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->