### PR TITLE
feat(fff-mcp): expose context parameter on the grep tool

### DIFF
--- a/crates/fff-mcp/src/server.rs
+++ b/crates/fff-mcp/src/server.rs
@@ -13,12 +13,23 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const SCAN_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
+const MAX_CONTEXT_LINES: usize = 100;
+
 fn normalize_max_results(raw: Option<f64>, default: usize) -> usize {
     match raw {
         None => default,
         Some(v) if v <= 0.0 || !v.is_finite() => default,
         Some(v) => (v.round() as usize).max(1),
     }
+}
+
+// Context lines are copied per match, so a bogus float must not saturate to usize::MAX.
+fn normalize_context(raw: Option<f64>) -> Option<usize> {
+    let v = raw?;
+    if !v.is_finite() || v < 0.0 {
+        return None;
+    }
+    Some((v.round() as usize).min(MAX_CONTEXT_LINES))
 }
 
 fn cleanup_fuzzy_query(s: &str) -> String {
@@ -101,6 +112,8 @@ pub struct GrepParams {
     pub cursor: Option<String>,
     /// Output format (default 'content').
     pub output_mode: Option<String>,
+    /// Context lines before/after each match.
+    pub context: Option<f64>,
 }
 
 fn deserialize_patterns<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
@@ -572,7 +585,7 @@ impl FffServer {
             max_results,
             params.cursor.as_deref(),
             output_mode,
-            None,
+            normalize_context(params.context),
         )?;
         self.maybe_append_update_notice(&mut result);
         Ok(result)
@@ -605,7 +618,7 @@ impl FffServer {
 impl FffServer {
     fn multi_grep_inner(&self, params: MultiGrepParams) -> Result<CallToolResult, ErrorData> {
         let max_results = normalize_max_results(params.max_results, 20);
-        let context = params.context.map(|v| v.round() as usize);
+        let context = normalize_context(params.context);
         let output_mode = OutputMode::new(params.output_mode.as_deref());
 
         let file_offset = params
@@ -718,6 +731,22 @@ mod tests {
         let via_pattern: GrepParams =
             serde_json::from_str(r#"{"pattern":"foo"}"#).expect("pattern alias");
         assert_eq!(via_pattern.query, "foo");
+    }
+
+    #[test]
+    fn normalize_context_rejects_bogus_and_caps() {
+        assert_eq!(normalize_context(None), None);
+        assert_eq!(normalize_context(Some(3.4)), Some(3));
+        assert_eq!(normalize_context(Some(-1.0)), None);
+        assert_eq!(normalize_context(Some(f64::NAN)), None);
+        assert_eq!(normalize_context(Some(1e308)), Some(MAX_CONTEXT_LINES));
+    }
+
+    #[test]
+    fn grep_params_parses_context() {
+        let params: GrepParams =
+            serde_json::from_str(r#"{"query":"foo","context":3}"#).expect("context field");
+        assert_eq!(params.context, Some(3.0));
     }
 
     #[test]


### PR DESCRIPTION
Closes #619 — adds the optional `context` param already supported by `multi_grep` to the single-pattern `grep` tool, which previously hardcoded it to `None`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional context setting for grep searches, allowing control over surrounding content shown with matches.
  * Context values are normalized automatically: fractional values are rounded, excessive values are capped, and invalid or negative values are ignored.
  * The setting is supported consistently for both single-pattern and multi-pattern searches.

* **Tests**
  * Added coverage for context validation, normalization, limits, and deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->