### PR TITLE
feat(fff-nvim): add clear_query picker action

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ require('fff').setup({
     grep_jump_to_next_file = { '<C-A-n>', '<A-Down>' },
     grep_jump_to_prev_file = { '<C-A-p>', '<A-Up>' },
     cycle_previous_query = '<C-Up>',
+    -- unbound by default, wipes the whole input line
+    -- clear_query = '<C-u>', -- overrides preview_scroll_up in insert mode
     toggle_select = '<Tab>',
     send_to_quickfix = '<C-q>',
     focus_list = '<leader>l',

--- a/lua/fff/conf.lua
+++ b/lua/fff/conf.lua
@@ -37,6 +37,7 @@ local M = {}
 --- @field insert_newline_escape string
 --- @field cycle_previous_query string
 --- @field cycle_forward_query string
+--- @field clear_query string|string[]|nil
 --- @field grep_jump_to_next_file string|string[]
 --- @field grep_jump_to_prev_file string|string[]
 --- @field toggle_select string

--- a/lua/fff/picker_ui/picker_ui.lua
+++ b/lua/fff/picker_ui/picker_ui.lua
@@ -52,6 +52,7 @@ M.on_input_change = search_manager.on_input_change
 M.cycle_grep_modes = search_manager.cycle_grep_modes
 M.recall_query_from_history = search_manager.recall_query_from_history
 M.cycle_forward_query = search_manager.cycle_forward_query
+M.clear_query = search_manager.clear_query
 M.get_suggestion_renderer = search_manager.get_suggestion_renderer
 
 -- Wire renderer module (list rendering, scroll, empty state)

--- a/lua/fff/picker_ui/search_manager.lua
+++ b/lua/fff/picker_ui/search_manager.lua
@@ -318,6 +318,19 @@ function M.recall_query_from_history()
   end)
 end
 
+function M.clear_query()
+  if not P.state.active then return end
+
+  S.history_offset = nil
+  vim.api.nvim_buf_set_lines(S.input_buf, 0, -1, false, { S.config.prompt })
+
+  vim.schedule(function()
+    if P.state.active and S.input_win and vim.api.nvim_win_is_valid(S.input_win) then
+      vim.api.nvim_win_set_cursor(S.input_win, { 1, #S.config.prompt })
+    end
+  end)
+end
+
 function M.cycle_forward_query()
   if not P.state.active then return end
 

--- a/lua/fff/picker_ui/ui_creator.lua
+++ b/lua/fff/picker_ui/ui_creator.lua
@@ -389,6 +389,8 @@ function M.setup_keymaps()
   set_keymap({ 'i', 'n' }, keymaps.toggle_select, P.toggle_select, input_opts)
   set_keymap({ 'i', 'n' }, keymaps.send_to_quickfix, P.send_to_quickfix, input_opts)
   set_keymap({ 'i', 'n' }, keymaps.cycle_grep_modes, P.cycle_grep_modes, input_opts)
+  -- last, so an explicitly configured key wins over the built-in bound to it
+  set_keymap('i', keymaps.clear_query, P.clear_query, input_opts)
 
   if keymaps.insert_newline_escape then
     -- Inserts the literal 2-char `\n` sequence which the grep engine


### PR DESCRIPTION
Closes #629 — adds an unbound-by-default `keymaps.clear_query` action that wipes the picker input line, which was previously only reachable as a side effect of `cycle_forward_query`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional keymap for clearing the entire search input.
  * Clearing the query resets search history and restores the configured prompt.
  * Supports assigning one or multiple keys, or leaving the action unbound.
  * The cursor is restored to the appropriate position after clearing.
  * Documented the new configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->