### PR TITLE
feat(fff-nvim): fire FFFOpen and FFFClose User autocmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,17 @@ Both `file_search` and `content_search` honour an optional `cwd` field. The firs
 - If the index is still warming up after a `change_indexing_directory`, you can pass `wait_for_index_ms = N` to block for up to `N` ms regardless of whether `cwd` triggered the swap. Pass `0` to skip waiting entirely (useful for fire-and-forget calls where partial results are acceptable).
 - Invalid or non-existent `cwd` paths return an empty result and emit an error via `vim.notify`.
 
+### Autocmds
+
+The picker fires `User` autocmds when it opens and closes. `FFFOpen` runs with the prompt window focused, `FFFClose` runs after every picker window is gone — so hide global UI, not window-local options of the picker itself:
+
+```lua
+vim.api.nvim_create_autocmd('User', {
+  pattern = { 'FFFOpen', 'FFFClose' },
+  callback = function(ev) vim.o.showtabline = ev.match == 'FFFOpen' and 0 or 2 end,
+})
+```
+
 ### Commands
 
 - `:FFFScan`. Rescan files.

--- a/lua/fff/picker_ui/layout_manager.lua
+++ b/lua/fff/picker_ui/layout_manager.lua
@@ -145,6 +145,8 @@ function M.close()
   S.combo_initial_cursor = nil
   P.reset_history_state()
   pcall(vim.api.nvim_del_augroup_by_name, 'fff_picker_focus')
+
+  vim.api.nvim_exec_autocmds('User', { pattern = 'FFFClose', modeline = false })
 end
 
 return M

--- a/lua/fff/picker_ui/picker_ui.lua
+++ b/lua/fff/picker_ui/picker_ui.lua
@@ -675,6 +675,8 @@ local function open_ui_with_state(query, results, location, merged_config, curre
   end
 
   M.monitor_scan_progress(0)
+
+  vim.api.nvim_exec_autocmds('User', { pattern = 'FFFOpen', modeline = false })
   return true
 end
 


### PR DESCRIPTION
Closes #708 — emits `User FFFOpen`/`User FFFClose` from the single open and close funnels so users can hook picker lifecycle (e.g. dimming the screen).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `FFFOpen` and `FFFClose` autocmd events to detect when the picker opens and closes.
* **Documentation**
  * Documented the new autocmd events with an example for toggling `showtabline` based on picker state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->