### PR TITLE
feat(pi-fff): expose followSymlinks option

### DIFF
--- a/packages/pi-fff/README.md
+++ b/packages/pi-fff/README.md
@@ -145,7 +145,7 @@ For persistent global configuration, create `pi-fff.json` in pi's agent director
   "enableFsRootScanning": false,
   "enableHomeDirScanning": true,
   "warnOnHomeDirScan": true,
-  "followSymlinks": false
+  "followSymlinks": true
 }
 ```
 
@@ -160,7 +160,7 @@ All fields are optional:
 | `enableFsRootScanning` | boolean | `false` |
 | `enableHomeDirScanning` | boolean | `true` |
 | `warnOnHomeDirScan` | boolean | `true` |
-| `followSymlinks` | boolean | `false` |
+| `followSymlinks` | boolean | `true` |
 
 CLI flags take precedence over environment variables, which take precedence over this file. A missing file is ignored. Malformed JSON, unknown fields, and invalid values stop the extension from loading and report the file path and error. `/fff-mode` changes the current session; it does not edit this file.
 
@@ -174,7 +174,7 @@ The file is global only. Project-level config cannot safely control tool names b
 - `--fff-enable-root-scan` — allow indexing when launched from `/` (also: `FFF_ENABLE_ROOT_SCAN=1` env). FFF refuses to init at the filesystem root by default.
 - `--fff-enable-home-scan` — index the home directory when launched from `$HOME` (also: `FFF_ENABLE_HOME_SCAN` env). Enabled by default. Disable with `--fff-enable-home-scan=false` or `FFF_ENABLE_HOME_SCAN=0` if your `$HOME` contains huge trees (toolchains, kernel sources, build outputs) that make the background index run for a long time. When launched from `$HOME` with this enabled, pi shows a warning that the whole home tree is being indexed.
 - `--fff-warn-home-scan` — show the warning notification when `$HOME` is indexed (also: `FFF_WARN_HOME_SCAN` env). Enabled by default. Disable with `--fff-warn-home-scan=false`, `FFF_WARN_HOME_SCAN=0`, or `"warnOnHomeDirScan": false` in `pi-fff.json`. Indexing and the footer status are unaffected.
-- `--fff-follow-symlinks` — index through directory symlinks (also: `FFF_FOLLOW_SYMLINKS=1` env, or `"followSymlinks": true` in `pi-fff.json`). Disabled by default, matching the Node SDK and fff.nvim. Enable it when the indexed tree reaches its real files through symlinks — a git worktree whose `docs/` links back to the main checkout, or a stowed dotfiles layout — otherwise those files are missing from `@`-mentions and from find/grep. The indexed tree must not contain symlink cycles: the walker does not de-duplicate visited targets, and a cycle can wedge the file watcher.
+- `--fff-follow-symlinks` — index through directory symlinks (also: `FFF_FOLLOW_SYMLINKS` env, or `"followSymlinks"` in `pi-fff.json`). Enabled by default: trees that reach their real files through links — a git worktree whose `docs/` links back to the main checkout, or a stowed dotfiles layout — would otherwise be missing from `@`-mentions and from find/grep with no visible sign. Disable with `--fff-follow-symlinks=false` or `FFF_FOLLOW_SYMLINKS=0` to keep the walk inside the real tree, which is worth doing when a linked target pulls in a large tree outside the workspace. Symlink cycles are detected and broken by the walker.
 
 ## Data
 

--- a/packages/pi-fff/README.md
+++ b/packages/pi-fff/README.md
@@ -144,7 +144,8 @@ For persistent global configuration, create `pi-fff.json` in pi's agent director
   "historyDbPath": "/path/to/history",
   "enableFsRootScanning": false,
   "enableHomeDirScanning": true,
-  "warnOnHomeDirScan": true
+  "warnOnHomeDirScan": true,
+  "followSymlinks": false
 }
 ```
 
@@ -159,6 +160,7 @@ All fields are optional:
 | `enableFsRootScanning` | boolean | `false` |
 | `enableHomeDirScanning` | boolean | `true` |
 | `warnOnHomeDirScan` | boolean | `true` |
+| `followSymlinks` | boolean | `false` |
 
 CLI flags take precedence over environment variables, which take precedence over this file. A missing file is ignored. Malformed JSON, unknown fields, and invalid values stop the extension from loading and report the file path and error. `/fff-mode` changes the current session; it does not edit this file.
 
@@ -172,6 +174,7 @@ The file is global only. Project-level config cannot safely control tool names b
 - `--fff-enable-root-scan` — allow indexing when launched from `/` (also: `FFF_ENABLE_ROOT_SCAN=1` env). FFF refuses to init at the filesystem root by default.
 - `--fff-enable-home-scan` — index the home directory when launched from `$HOME` (also: `FFF_ENABLE_HOME_SCAN` env). Enabled by default. Disable with `--fff-enable-home-scan=false` or `FFF_ENABLE_HOME_SCAN=0` if your `$HOME` contains huge trees (toolchains, kernel sources, build outputs) that make the background index run for a long time. When launched from `$HOME` with this enabled, pi shows a warning that the whole home tree is being indexed.
 - `--fff-warn-home-scan` — show the warning notification when `$HOME` is indexed (also: `FFF_WARN_HOME_SCAN` env). Enabled by default. Disable with `--fff-warn-home-scan=false`, `FFF_WARN_HOME_SCAN=0`, or `"warnOnHomeDirScan": false` in `pi-fff.json`. Indexing and the footer status are unaffected.
+- `--fff-follow-symlinks` — index through directory symlinks (also: `FFF_FOLLOW_SYMLINKS=1` env, or `"followSymlinks": true` in `pi-fff.json`). Disabled by default, matching the Node SDK and fff.nvim. Enable it when the indexed tree reaches its real files through symlinks — a git worktree whose `docs/` links back to the main checkout, or a stowed dotfiles layout — otherwise those files are missing from `@`-mentions and from find/grep. The indexed tree must not contain symlink cycles: the walker does not de-duplicate visited targets, and a cycle can wedge the file watcher.
 
 ## Data
 

--- a/packages/pi-fff/pi-fff.schema.json
+++ b/packages/pi-fff/pi-fff.schema.json
@@ -44,8 +44,8 @@
     },
     "followSymlinks": {
       "type": "boolean",
-      "default": false,
-      "description": "Indexes through directory symlinks, e.g. a git worktree or stow layout whose files live behind links. The tree must not contain symlink cycles."
+      "default": true,
+      "description": "Indexes through directory symlinks, e.g. a git worktree or stow layout whose files live behind links. Set to false to keep the walk inside the real tree."
     }
   }
 }

--- a/packages/pi-fff/pi-fff.schema.json
+++ b/packages/pi-fff/pi-fff.schema.json
@@ -41,6 +41,11 @@
       "type": "boolean",
       "default": true,
       "description": "Shows a warning notification when the home directory is indexed."
+    },
+    "followSymlinks": {
+      "type": "boolean",
+      "default": false,
+      "description": "Indexes through directory symlinks, e.g. a git worktree or stow layout whose files live behind links. The tree must not contain symlink cycles."
     }
   }
 }

--- a/packages/pi-fff/src/aux-finders.ts
+++ b/packages/pi-fff/src/aux-finders.ts
@@ -16,6 +16,7 @@ interface AuxPicker {
 export interface AuxOpts {
   enableFsRootScanning: boolean;
   enableHomeDirScanning?: boolean;
+  followSymlinks?: boolean;
   pickers: FilePickerFactory;
   // Called before a newly spawned aux picker starts a scan that covers $HOME.
   onHomeDirScan?: (root: string) => void;
@@ -104,6 +105,7 @@ export class AuxFinderPool {
       basePath: root,
       enableHomeDirScanning,
       enableFsRootScanning: this.opts.enableFsRootScanning,
+      followSymlinks: this.opts.followSymlinks,
     });
 
     const entry: AuxPicker = { root, finder, lastUsed: Date.now() };

--- a/packages/pi-fff/src/config.ts
+++ b/packages/pi-fff/src/config.ts
@@ -15,6 +15,7 @@ export interface FffConfig {
   enableFsRootScanning?: boolean;
   enableHomeDirScanning?: boolean;
   warnOnHomeDirScan?: boolean;
+  followSymlinks?: boolean;
 }
 
 const CONFIG_KEYS = new Set<keyof FffConfig>([
@@ -25,6 +26,7 @@ const CONFIG_KEYS = new Set<keyof FffConfig>([
   "enableFsRootScanning",
   "enableHomeDirScanning",
   "warnOnHomeDirScan",
+  "followSymlinks",
 ]);
 
 export function loadConfig(agentDir = piDataDir()): FffConfig {
@@ -67,6 +69,7 @@ export function loadConfig(agentDir = piDataDir()): FffConfig {
   validateBoolean(configPath, parsed, "enableFsRootScanning");
   validateBoolean(configPath, parsed, "enableHomeDirScanning");
   validateBoolean(configPath, parsed, "warnOnHomeDirScan");
+  validateBoolean(configPath, parsed, "followSymlinks");
 
   return parsed as FffConfig;
 }
@@ -97,7 +100,11 @@ function validateString(
 function validateBoolean(
   configPath: string,
   config: Record<string, unknown>,
-  key: "enableFsRootScanning" | "enableHomeDirScanning" | "warnOnHomeDirScan",
+  key:
+    | "enableFsRootScanning"
+    | "enableHomeDirScanning"
+    | "warnOnHomeDirScan"
+    | "followSymlinks",
 ): void {
   const value = config[key];
   if (value !== undefined && typeof value !== "boolean") {

--- a/packages/pi-fff/src/file-picker.ts
+++ b/packages/pi-fff/src/file-picker.ts
@@ -5,6 +5,7 @@ export interface PickerOptions {
   basePath: string;
   enableHomeDirScanning?: boolean;
   enableFsRootScanning?: boolean;
+  followSymlinks?: boolean;
 }
 
 /** Opens every picker in this pi process — the cwd picker and the aux pickers —

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -345,7 +345,7 @@ export default function fffExtension(pi: ExtensionAPI) {
   let enableFsRootScanning = false;
   let enableHomeDirScanning = true;
   let warnOnHomeDirScan = true;
-  let followSymlinks = false;
+  let followSymlinks = true;
 
   function setMode(mode: FffMode): void {
     currentMode = mode;
@@ -395,13 +395,13 @@ export default function fffExtension(pi: ExtensionAPI) {
       true,
       parseBoolean,
     );
-    // Symlinked trees (git worktrees, stow layouts) are skipped by default, and
-    // loop protection is the caller's job, so following stays opt-in.
+    // On by default: worktree and stow layouts reach their files through links,
+    // and an agent silently missing them is worse than the extra walk.
     followSymlinks = getConfigValue(
       "fff-follow-symlinks",
       "FFF_FOLLOW_SYMLINKS",
       config.followSymlinks,
-      false,
+      true,
       parseBoolean,
     );
   }
@@ -691,7 +691,7 @@ export default function fffExtension(pi: ExtensionAPI) {
 
   pi.registerFlag("fff-follow-symlinks", {
     description:
-      "Index through directory symlinks, e.g. a git worktree or stow layout (also: FFF_FOLLOW_SYMLINKS env). Disabled by default; the tree must not contain symlink cycles",
+      "Index through directory symlinks, e.g. a git worktree or stow layout (default true; disable with --fff-follow-symlinks=false or FFF_FOLLOW_SYMLINKS=0)",
     type: "boolean",
   });
 

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -345,6 +345,7 @@ export default function fffExtension(pi: ExtensionAPI) {
   let enableFsRootScanning = false;
   let enableHomeDirScanning = true;
   let warnOnHomeDirScan = true;
+  let followSymlinks = false;
 
   function setMode(mode: FffMode): void {
     currentMode = mode;
@@ -394,6 +395,15 @@ export default function fffExtension(pi: ExtensionAPI) {
       true,
       parseBoolean,
     );
+    // Symlinked trees (git worktrees, stow layouts) are skipped by default, and
+    // loop protection is the caller's job, so following stays opt-in.
+    followSymlinks = getConfigValue(
+      "fff-follow-symlinks",
+      "FFF_FOLLOW_SYMLINKS",
+      config.followSymlinks,
+      false,
+      parseBoolean,
+    );
   }
 
   function getMode(): FffMode {
@@ -440,6 +450,7 @@ export default function fffExtension(pi: ExtensionAPI) {
     auxPool = new AuxFinderPool({
       enableFsRootScanning,
       enableHomeDirScanning,
+      followSymlinks,
       onHomeDirScan: warnHomeDirScan,
       pickers,
     });
@@ -466,6 +477,7 @@ export default function fffExtension(pi: ExtensionAPI) {
         basePath: cwd,
         enableHomeDirScanning,
         enableFsRootScanning,
+        followSymlinks,
       });
       finderCwd = cwd;
       return mainFinder;
@@ -674,6 +686,12 @@ export default function fffExtension(pi: ExtensionAPI) {
   pi.registerFlag("fff-enable-home-scan", {
     description:
       "Index the home dir when launched from $HOME (default true; disable with --fff-enable-home-scan=false or FFF_ENABLE_HOME_SCAN=0)",
+    type: "boolean",
+  });
+
+  pi.registerFlag("fff-follow-symlinks", {
+    description:
+      "Index through directory symlinks, e.g. a git worktree or stow layout (also: FFF_FOLLOW_SYMLINKS env). Disabled by default; the tree must not contain symlink cycles",
     type: "boolean",
   });
 

--- a/packages/pi-fff/test/aux-pool.test.ts
+++ b/packages/pi-fff/test/aux-pool.test.ts
@@ -84,6 +84,13 @@ describe("AuxFinderPool covering reuse", () => {
     expect(created.length).toBe(1);
   });
 
+  test("passes followSymlinks through to the aux picker", async () => {
+    const pool = makePool({ followSymlinks: true });
+    await pool.acquire("/a/b/c");
+
+    expect(createOptions[0]?.followSymlinks).toBe(true);
+  });
+
   test("does not reuse a picker rooted deeper than the requested path", async () => {
     const pool = makePool();
     await pool.acquire("/a/b/c");

--- a/packages/pi-fff/test/config.test.ts
+++ b/packages/pi-fff/test/config.test.ts
@@ -32,6 +32,7 @@ describe("loadConfig", () => {
       enableFsRootScanning: true,
       enableHomeDirScanning: false,
       warnOnHomeDirScan: false,
+      followSymlinks: true,
     };
     writeConfig(config);
 
@@ -68,6 +69,7 @@ describe("loadConfig", () => {
       [{ enableFsRootScanning: 1 }, '"enableFsRootScanning" must be a boolean'],
       [{ enableHomeDirScanning: "false" }, '"enableHomeDirScanning" must be a boolean'],
       [{ warnOnHomeDirScan: "false" }, '"warnOnHomeDirScan" must be a boolean'],
+      [{ followSymlinks: "true" }, '"followSymlinks" must be a boolean'],
     ];
 
     for (const [config, message] of cases) {

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -191,6 +191,7 @@ const CONFIG_ENV_KEYS = [
   "FFF_ENABLE_ROOT_SCAN",
   "FFF_ENABLE_HOME_SCAN",
   "FFF_WARN_HOME_SCAN",
+  "FFF_FOLLOW_SYMLINKS",
 ] as const;
 
 const savedEnv: Record<string, string | undefined> = {};
@@ -227,6 +228,7 @@ describe("pi-fff global config", () => {
       historyDbPath: "/config/history",
       enableFsRootScanning: true,
       enableHomeDirScanning: false,
+      followSymlinks: true,
     });
 
     const setup = await start();
@@ -242,6 +244,7 @@ describe("pi-fff global config", () => {
       aiMode: true,
       enableHomeDirScanning: false,
       enableFsRootScanning: true,
+      followSymlinks: true,
     });
     await shutdown(setup);
   });
@@ -259,10 +262,12 @@ describe("pi-fff global config", () => {
     process.env.FFF_HISTORY_DB = "/env/history";
     process.env.FFF_ENABLE_ROOT_SCAN = "1";
     process.env.FFF_ENABLE_HOME_SCAN = "1";
+    process.env.FFF_FOLLOW_SYMLINKS = "1";
 
     const setup = await start("tools-and-ui", undefined, {
       "fff-frecency-db": "/flag/frecency",
       "fff-enable-root-scan": false,
+      "fff-follow-symlinks": false,
     });
     const toolNames = setup.pi.registerTool.mock.calls.map(([tool]) => tool.name);
 
@@ -275,7 +280,19 @@ describe("pi-fff global config", () => {
       aiMode: true,
       enableHomeDirScanning: true,
       enableFsRootScanning: false,
+      followSymlinks: false,
     });
+    await shutdown(setup);
+  });
+
+  // #627: worktree and stow layouts reach their files through symlinks, which the
+  // walker skips unless this is on.
+  test("follows symlinks when the environment enables them", async () => {
+    process.env.FFF_FOLLOW_SYMLINKS = "1";
+
+    const setup = await start();
+
+    expect((createCalls[0] as { followSymlinks: boolean }).followSymlinks).toBe(true);
     await shutdown(setup);
   });
 
@@ -476,6 +493,7 @@ describe("pi-fff autocomplete registration", () => {
         aiMode: true,
         enableHomeDirScanning: true,
         enableFsRootScanning: false,
+        followSymlinks: false,
       },
     ]);
   });

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -228,7 +228,7 @@ describe("pi-fff global config", () => {
       historyDbPath: "/config/history",
       enableFsRootScanning: true,
       enableHomeDirScanning: false,
-      followSymlinks: true,
+      followSymlinks: false,
     });
 
     const setup = await start();
@@ -244,7 +244,7 @@ describe("pi-fff global config", () => {
       aiMode: true,
       enableHomeDirScanning: false,
       enableFsRootScanning: true,
-      followSymlinks: true,
+      followSymlinks: false,
     });
     await shutdown(setup);
   });
@@ -285,14 +285,14 @@ describe("pi-fff global config", () => {
     await shutdown(setup);
   });
 
-  // #627: worktree and stow layouts reach their files through symlinks, which the
-  // walker skips unless this is on.
-  test("follows symlinks when the environment enables them", async () => {
-    process.env.FFF_FOLLOW_SYMLINKS = "1";
+  // #627: worktree and stow layouts reach their files through symlinks, so following
+  // them is the default and the environment is the way out.
+  test("stops following symlinks when the environment disables them", async () => {
+    process.env.FFF_FOLLOW_SYMLINKS = "0";
 
     const setup = await start();
 
-    expect((createCalls[0] as { followSymlinks: boolean }).followSymlinks).toBe(true);
+    expect((createCalls[0] as { followSymlinks: boolean }).followSymlinks).toBe(false);
     await shutdown(setup);
   });
 
@@ -493,7 +493,7 @@ describe("pi-fff autocomplete registration", () => {
         aiMode: true,
         enableHomeDirScanning: true,
         enableFsRootScanning: false,
-        followSymlinks: false,
+        followSymlinks: true,
       },
     ]);
   });


### PR DESCRIPTION
Follow-up to #627 / #628: the option exists in the SDK, but the pi extension never passes it.

## Problem

FFF skips symlinks while walking, so any indexed tree that reaches its real files through links is invisible to pi-fff. Two layouts hit this:

- a git worktree whose `docs/` (or `.pi/`) is a symlink back into the main checkout, so the content has a single source of truth;
- the stowed dotfiles layout from #627, which is what motivated exposing the option in the first place.

In both cases `@`-mentions and the FFF-backed find/grep tools silently miss those files, while the same index rooted at the real directory finds them. Measured on a worktree here: `mixedSearch("repomap")` returns `[]` for the linked tree and `["docs/repomap.md"]` once `followSymlinks` is on.

#628 threaded `follow_symlinks` through `fff-c`, `fff-mcp`, `fff-python` and `@ff-labs/fff-node`, but `packages/pi-fff` was not part of it, so there is no way to reach the option from pi — not by flag, env, or `pi-fff.json`.

## Change

- `followSymlinks` joins the existing startup options and resolves through `getConfigValue()`, so precedence stays `--fff-follow-symlinks` > `FFF_FOLLOW_SYMLINKS` > `pi-fff.json` > default, exactly like the scanning options added in #790.
- Passed to both the cwd picker and the aux pickers. Only wiring the main finder would make absolute-path `fffind` / `ffgrep` disagree with workspace-relative queries about which files exist.
- `FffConfig`, the strict key check, the boolean validation, `pi-fff.schema.json` and the README config table / flag list all pick up the new key.

**Default is `true`** ([per review](https://github.com/dmtrKovalenko/fff/pull/818#issuecomment-5413518416)). A missing file has no failure mode an agent can see — it just gets an empty result and falls back to shell `find`/`grep`, which is the thing pi-fff exists to replace. `--fff-follow-symlinks=false` / `FFF_FOLLOW_SYMLINKS=0` / `"followSymlinks": false` are the opt-out. This diverges from `@ff-labs/fff-node`, the Rust core and fff.nvim, which stay `false`; pi-fff already diverges the same way on `enableHomeDirScanning`.

The first revision of this PR defaulted to `false` and repeated the cycle warning from `fff-c/src/ffi_types.rs` ("without external loop protection cyclic symlinks can wedge the watcher"). That warning is stale: the shipping zlob walker keeps a global `(dev, ino)` visited set (`zlob@v1.6.3 src/walker/worker.zig:42,123-171,360,643-647`, and `WalkFlags::FOLLOW_SYMLINKS` is documented as "cycles are detected and broken"), and the `ignore` fallback compares symlink targets against ancestor handles and returns `Error::Loop`, which `walk/ripgrep.rs:44-47` skips over. Cycles are the walker's problem, not the caller's, so the README no longer claims otherwise. The `ffi_types.rs` comment is left alone here — it belongs to a different package.

No `AGENTS.md`-style project config (`.pi/pi-fff.json`) is introduced here — the README already documents why the file is global only, and per-project scope would be a separate feature with its own trust story.

## Two behaviours worth a maintainer call

Neither is introduced by this PR, but defaulting to `true` widens both. Happy to bound either one here or in a follow-up.

- **Scope.** pi-fff enables `$HOME` scanning by default and #743 recorded a multi-hour, ~500 MB/s scan from a large `$HOME`. `ignore.rs` excludes hidden entries, `node_modules` and toolchain caches on non-git roots, but that is a filter, not a boundary — one directory symlink can now pull a large tree from outside `$HOME` or the workspace into the walk. `file_picker.rs:867-877` only guards the case where the picker base *is* `$HOME`.
- **Watcher coherence.** The initial scan follows symlinks, but the debouncer is fixed at `with_follow_symlinks(false)` (`background_watcher.rs:184-190`) while `index_new_directory` reads the picker's `follows_symlinks()` (`:717-735`). On macOS/Windows there is a single recursive watch on the base, so edits to a target outside the base may never reach the index after the first scan. Untested; Linux watches indexed directories individually and is probably fine.

## Test plan

```
$ cd packages/pi-fff && bun test test/
 81 pass, 0 fail, 204 expect() calls
```

Coverage:

- `config.test.ts` — `followSymlinks` round-trips through the full-option config, and `"true"` (string) is rejected as not a boolean.
- `extension.test.ts` — default `true` reaches `FileFinder.create`; `FFF_FOLLOW_SYMLINKS=0` turns it off; `"followSymlinks": false` in `pi-fff.json` turns it off; `--fff-follow-symlinks=false` beats `FFF_FOLLOW_SYMLINKS=1`, keeping the documented precedence.
- `aux-pool.test.ts` — an aux picker created for an out-of-workspace root inherits the setting.

```
$ cd packages && bunx oxfmt --check pi-fff/src pi-fff/test   # all matched files use the correct format
$ cd packages && bunx oxlint pi-fff/src pi-fff/test          # clean
```

`bun run typecheck` in `packages/pi-fff` reports the same six pre-existing errors on this branch as on an untouched `upstream/main` worktree (unresolved `@ff-labs/fff-node` types plus two implicit `any`s, all from the unbuilt native package) — no new ones.

Behaviour was also verified end-to-end against a real worktree with a symlinked `docs/`: with the extension patched to pass the option, a fresh `pi -p` session's `fffind repomap` returns `docs/repomap.md` as the top hit; without it, the tree is absent from the index.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Symlink traversal during indexing is now enabled by default.
  - Disable it with the `--fff-follow-symlinks` flag, environment variable, or configuration setting.
  - Auxiliary indexing and autocomplete honor the symlink traversal setting.
- **Documentation**
  - Updated configuration guidance to explain the new default and how to restrict indexing to the real directory tree.
- **Bug Fixes**
  - Improved validation for symlink traversal configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->