### PR TITLE
fix: default fff-mcp log path to XDG state dir (#820)

### DIFF
--- a/crates/fff-mcp/src/healthcheck.rs
+++ b/crates/fff-mcp/src/healthcheck.rs
@@ -92,14 +92,15 @@ pub fn run_healthcheck(args: &Args) -> Result<(), Box<dyn std::error::Error>> {
 
     // 5. Log path hint (per-session files written next to this path)
     if let Some(ref log_path) = args.log_file {
-        let parent_ok = std::path::Path::new(log_path)
+        let parent_ok = log_path
             .parent()
             .is_some_and(|p| p.is_dir() || p.parent().is_some());
+        let log_path = log_path.to_string_lossy();
         all_ok &= check(
             "Log path",
             parent_ok,
             if parent_ok {
-                log_path
+                &log_path
             } else {
                 "parent directory does not exist"
             },

--- a/crates/fff-mcp/src/main.rs
+++ b/crates/fff-mcp/src/main.rs
@@ -243,12 +243,22 @@ fn absolute_env(key: &str) -> Option<PathBuf> {
         .filter(|value| value.is_absolute())
 }
 
-// Relative homes would break the absolute-path contract of the default above.
+// Relative homes would break the absolute-path contract of the default above,
+// and TMPDIR can be relative too, so every fallback is filtered for absoluteness.
 fn dirs_home() -> PathBuf {
     absolute_env("HOME")
         .or_else(|| absolute_env("USERPROFILE"))
-        .unwrap_or_else(std::env::temp_dir)
+        .or_else(|| {
+            let tmp = std::env::temp_dir();
+            tmp.is_absolute().then_some(tmp)
+        })
+        .unwrap_or_else(|| PathBuf::from(FALLBACK_ROOT))
 }
+
+#[cfg(not(windows))]
+const FALLBACK_ROOT: &str = "/tmp";
+#[cfg(windows)]
+const FALLBACK_ROOT: &str = "C:\\Windows\\Temp";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -259,13 +269,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         return healthcheck::run_healthcheck(&args);
     }
 
-    let log_file = args
-        .log_file
-        .as_deref()
-        .unwrap_or(Path::new(""))
-        .to_string_lossy();
-    if let Err(e) = fff::log::init_tracing(&log_file, args.log_level.as_deref(), None) {
-        eprintln!("Warning: Failed to init tracing: {}", e);
+    // init_tracing takes &str (stable across fff-c/-python/-nvim), so reject a
+    // non-UTF-8 --log-file rather than let to_string_lossy retarget the file.
+    let log_file = args.log_file.as_deref().unwrap_or(Path::new(""));
+    match log_file.to_str() {
+        Some(log_file) => {
+            if let Err(e) = fff::log::init_tracing(log_file, args.log_level.as_deref(), None) {
+                eprintln!("Warning: Failed to init tracing: {}", e);
+            }
+        }
+        None => eprintln!(
+            "Warning: --log-file is not valid UTF-8, file logging disabled: {}",
+            log_file.display()
+        ),
     }
 
     let base_path = args.base_path.unwrap_or_else(|| {

--- a/crates/fff-mcp/src/main.rs
+++ b/crates/fff-mcp/src/main.rs
@@ -6,6 +6,7 @@ mod parent;
 mod server;
 mod update_check;
 
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use clap::Parser;
@@ -117,9 +118,10 @@ pub(crate) struct Args {
 
     /// Path-shape hint for per-session log files.
     /// Each fff-mcp startup writes a fresh sibling file `<stem>+<UTC-timestamp>+<pid>.<ext>`
-    /// Defaults to `$XDG_STATE_HOME/fff/fff_mcp.log` (`~/.local/state/fff/fff_mcp.log`).
+    /// Defaults to `$XDG_STATE_HOME/fff/fff_mcp.log` (`~/.local/state/fff/fff_mcp.log`),
+    /// on Windows to `%LOCALAPPDATA%\fff\fff_mcp.log` (`~\AppData\Local\fff\fff_mcp.log`).
     #[arg(long = "log-file")]
-    log_file: Option<String>,
+    log_file: Option<PathBuf>,
 
     /// Log level (e.g. trace, debug, info, warn, error).
     #[arg(long = "log-level")]
@@ -208,7 +210,7 @@ fn resolve_defaults(args: &mut Args) {
         .into_iter()
         .flatten()
     {
-        if let Some(parent) = std::path::Path::new(path).parent() {
+        if let Some(parent) = Path::new(path).parent() {
             let _ = std::fs::create_dir_all(parent);
         }
     }
@@ -221,30 +223,31 @@ fn resolve_defaults(args: &mut Args) {
 // Own subdirectory: log rotation read_dir's the parent on every startup, and the
 // per-session `<stem>+<ts>+<pid>.log` files otherwise pile up in its root.
 #[cfg(not(windows))]
-fn default_log_file() -> String {
+fn default_log_file() -> PathBuf {
     let base =
-        absolute_env("XDG_STATE_HOME").unwrap_or_else(|| format!("{}/.local/state", dirs_home()));
-    format!("{}/fff/fff_mcp.log", base)
+        absolute_env("XDG_STATE_HOME").unwrap_or_else(|| dirs_home().join(".local").join("state"));
+    base.join("fff").join("fff_mcp.log")
 }
 
 #[cfg(windows)]
-fn default_log_file() -> String {
+fn default_log_file() -> PathBuf {
     let base =
-        absolute_env("LOCALAPPDATA").unwrap_or_else(|| format!("{}\\AppData\\Local", dirs_home()));
-    format!("{}\\fff\\fff_mcp.log", base)
+        absolute_env("LOCALAPPDATA").unwrap_or_else(|| dirs_home().join("AppData").join("Local"));
+    base.join("fff").join("fff_mcp.log")
 }
 
 // XDG spec: a non-absolute value must be ignored as if unset.
-fn absolute_env(key: &str) -> Option<String> {
-    std::env::var(key)
-        .ok()
-        .filter(|value| std::path::Path::new(value).is_absolute())
+fn absolute_env(key: &str) -> Option<PathBuf> {
+    std::env::var_os(key)
+        .map(PathBuf::from)
+        .filter(|value| value.is_absolute())
 }
 
-fn dirs_home() -> String {
-    std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .unwrap_or_else(|_| "/tmp".to_string())
+// Relative homes would break the absolute-path contract of the default above.
+fn dirs_home() -> PathBuf {
+    absolute_env("HOME")
+        .or_else(|| absolute_env("USERPROFILE"))
+        .unwrap_or_else(std::env::temp_dir)
 }
 
 #[tokio::main]
@@ -256,8 +259,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         return healthcheck::run_healthcheck(&args);
     }
 
-    let log_file = args.log_file.as_deref().unwrap_or("");
-    if let Err(e) = fff::log::init_tracing(log_file, args.log_level.as_deref(), None) {
+    let log_file = args
+        .log_file
+        .as_deref()
+        .unwrap_or(Path::new(""))
+        .to_string_lossy();
+    if let Err(e) = fff::log::init_tracing(&log_file, args.log_level.as_deref(), None) {
         eprintln!("Warning: Failed to init tracing: {}", e);
     }
 
@@ -472,7 +479,7 @@ mod tests {
 
     #[test]
     fn default_log_file_lives_in_own_dir() {
-        let path = std::path::PathBuf::from(default_log_file());
+        let path = default_log_file();
         assert!(path.is_absolute(), "{}", path.display());
         assert_eq!(path.file_name().unwrap(), "fff_mcp.log");
         assert_eq!(path.parent().unwrap().file_name().unwrap(), "fff");

--- a/crates/fff-mcp/src/main.rs
+++ b/crates/fff-mcp/src/main.rs
@@ -117,6 +117,7 @@ pub(crate) struct Args {
 
     /// Path-shape hint for per-session log files.
     /// Each fff-mcp startup writes a fresh sibling file `<stem>+<UTC-timestamp>+<pid>.<ext>`
+    /// Defaults to `$XDG_STATE_HOME/fff/fff_mcp.log` (`~/.local/state/fff/fff_mcp.log`).
     #[arg(long = "log-file")]
     log_file: Option<String>,
 
@@ -213,14 +214,31 @@ fn resolve_defaults(args: &mut Args) {
     }
 
     if args.log_file.is_none() {
-        let home = dirs_home();
-        let is_windows = cfg!(target_os = "windows");
-        args.log_file = Some(if is_windows {
-            format!("{}\\AppData\\Local\\fff_mcp.log", home)
-        } else {
-            format!("{}/.cache/fff_mcp.log", home)
-        });
+        args.log_file = Some(default_log_file());
     }
+}
+
+// Own subdirectory: log rotation read_dir's the parent on every startup, and the
+// per-session `<stem>+<ts>+<pid>.log` files otherwise pile up in its root.
+#[cfg(not(windows))]
+fn default_log_file() -> String {
+    let base =
+        absolute_env("XDG_STATE_HOME").unwrap_or_else(|| format!("{}/.local/state", dirs_home()));
+    format!("{}/fff/fff_mcp.log", base)
+}
+
+#[cfg(windows)]
+fn default_log_file() -> String {
+    let base =
+        absolute_env("LOCALAPPDATA").unwrap_or_else(|| format!("{}\\AppData\\Local", dirs_home()));
+    format!("{}\\fff\\fff_mcp.log", base)
+}
+
+// XDG spec: a non-absolute value must be ignored as if unset.
+fn absolute_env(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .filter(|value| std::path::Path::new(value).is_absolute())
 }
 
 fn dirs_home() -> String {
@@ -446,4 +464,17 @@ fn watchdog_interval() -> Duration {
         return Duration::from_millis(milliseconds);
     }
     Duration::from_secs(60)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_log_file_lives_in_own_dir() {
+        let path = std::path::PathBuf::from(default_log_file());
+        assert!(path.is_absolute(), "{}", path.display());
+        assert_eq!(path.file_name().unwrap(), "fff_mcp.log");
+        assert_eq!(path.parent().unwrap().file_name().unwrap(), "fff");
+    }
 }


### PR DESCRIPTION
Closes #820

## Root cause
`resolve_defaults` defaulted the log hint to `~/.cache/fff_mcp.log` (`crates/fff-mcp/src/main.rs:221` pre-fix). `init_tracing` derives a per-session sibling `<stem>+<ts>+<pid>.<ext>` from that hint (`crates/fff-core/src/log.rs:165-174`) and retains 20 of them, so every startup dropped another `fff_mcp+...log` into the root of `~/.cache`. Rotation also `read_dir`s the hint's parent and `metadata()`s each candidate entry (`crates/fff-core/src/log.rs:176-205`) — on a real machine that means stat-ing the whole `~/.cache` on each launch.

## Fix
Default resolves to `$XDG_STATE_HOME/fff/fff_mcp.log`, falling back to `~/.local/state/fff/fff_mcp.log`; Windows uses `%LOCALAPPDATA%\fff\fff_mcp.log`. A non-absolute `XDG_STATE_HOME` is ignored per the XDG spec. `--log-file` is unchanged, `init_tracing` already `create_dir_all`s the parent.

## Steps to reproduce
On pre-fix `main`:

```sh
cargo build -p fff-mcp
rm -rf /tmp/fff820 && mkdir -p /tmp/fff820/home /tmp/fff820/work
env -u XDG_STATE_HOME HOME=/tmp/fff820/home timeout 6 ./target/debug/fff-mcp /tmp/fff820/work </dev/null >/dev/null 2>&1
find /tmp/fff820/home
```

Expected: log file under a dedicated `fff` app directory.

Actual (pre-fix):

```
/tmp/fff820/home
/tmp/fff820/home/.cache
/tmp/fff820/home/.cache/fff_mcp+1787677356+38959.log
```

## How verified
Same repro post-fix, plus XDG override and relative-path cases:

```
=== default (no XDG_STATE_HOME) ===
/tmp/fff820/home/.local/state/fff/fff_mcp+1787677461+51836.log
=== XDG_STATE_HOME=/tmp/fff820/home2/xdgstate ===
/tmp/fff820/home2/xdgstate/fff/fff_mcp+1787677461+51859.log
=== XDG_STATE_HOME=relative/state (ignored) ===
/tmp/fff820/home3/.local/state/fff/fff_mcp+1787677461+51885.log
```

`cargo clippy -p fff-mcp --all-targets` clean, `cargo test -p fff-mcp` — 18 passed + 2 integration passed, 0 failed.

Automated triage via Gustav. Honk-Honk 🪿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default log files now use platform-appropriate locations:
    * `$XDG_STATE_HOME` on Unix-like systems
    * `%LOCALAPPDATA%\fff\fff_mcp.log` on Windows
    * Home-directory or system temporary-directory fallbacks when needed
  * Log paths are validated to ensure they are absolute.

* **Bug Fixes**
  * Invalid non-UTF-8 log paths are now handled safely, with file logging disabled and a warning displayed.

* **Documentation**
  * Updated help text to describe the Windows default log location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->