### PR TITLE
feat(fff-bun): recognise FreeBSD as a platform

### DIFF
--- a/packages/fff-bun/package.json
+++ b/packages/fff-bun/package.json
@@ -33,7 +33,8 @@
     "darwin",
     "linux",
     "win32",
-    "android"
+    "android",
+    "freebsd"
   ],
   "cpu": [
     "x64",

--- a/packages/fff-bun/src/platform.ts
+++ b/packages/fff-bun/src/platform.ts
@@ -20,6 +20,8 @@ export function getTriple(): string {
     osName = detectLinuxLibc();
   } else if (platform === "win32") {
     osName = "pc-windows-msvc";
+  } else if (platform === "freebsd") {
+    osName = "unknown-freebsd";
   } else {
     throw new Error(`Unsupported platform: ${platform}`);
   }
@@ -110,6 +112,8 @@ const TRIPLE_TO_NPM_PACKAGE: Record<string, string> = {
   "x86_64-pc-windows-msvc": "@ff-labs/fff-bin-win32-x64",
   "aarch64-pc-windows-msvc": "@ff-labs/fff-bin-win32-arm64",
   "aarch64-linux-android": "@ff-labs/fff-bin-android-arm64",
+  "x86_64-unknown-freebsd": "@ff-labs/fff-bin-freebsd-x64",
+  "aarch64-unknown-freebsd": "@ff-labs/fff-bin-freebsd-arm64",
 };
 
 /**


### PR DESCRIPTION
## Summary

Two small changes so `@ff-labs/fff-bun` can be used on FreeBSD. **The Rust side needs nothing** — `cargo build --release -p fff-c` builds `crates/fff-c` into a working `libfff_c.so` on FreeBSD exactly as-is. This is purely the JS platform plumbing.

## The two blockers

**1. `package.json` `"os"` omits `freebsd`**, so bun/npm skip installing the package altogether. A consumer importing it gets:

```
error: Cannot find module '@ff-labs/fff-bun' from '.../fff.bun.ts'
```

**2. `getTriple()` throws before any lookup can happen.** It is called from `getNpmPackageName()`, which `resolveFromNpmPackage()` invokes *outside* its `try`/`catch`:

```ts
function resolveFromNpmPackage(): string | null {
  const packageName = getNpmPackageName();   // <-- throws here on freebsd

  try {
    // ...
  } catch {
    // Package not installed - this is expected on unsupported platforms
  }
  return null;
}
```

So `Unsupported platform: freebsd` escapes `findBinary()` entirely, instead of degrading to "no prebuilt for this platform, fall through to the dev build". The dev-build fallback already exists and works fine — it is just never reached.

## About the unpublished package names

The two triples added to `TRIPLE_TO_NPM_PACKAGE` point at `@ff-labs/fff-bin-freebsd-{x64,arm64}`, which do not exist on npm. This is deliberate and harmless: `resolveFromNpmPackage()` catches the resolution failure and `findBinary()` moves on to the locally built library. If you ever publish those packages the mapping goes live with no further code change.

The alternative — wrapping `getNpmPackageName()` in a try/catch at the call site — would also work and would not name unpublished packages. Happy to switch to that if you prefer it; I went with the mapping because it keeps the "which platforms exist" knowledge in one table.

## Verification

FreeBSD 15.1-RC2, amd64, bun 1.4.0, rustc 1.96.1:

- `cargo build --release -p fff-c` → `target/release/libfff_c.so`, unpatched.
- `findBinary()` resolves it, `dlopen` succeeds through `bun:ffi`.
- `FileFinder.create({ basePath })` + `waitForScan()` + `fileSearch()` return real results — 100 hits over a live tree, with `relativePath`, `fileName`, `gitStatus`, `size`, `modified` all populated correctly.

## Not covered

`packages/fff-node/src/platform.ts` has the same `Unsupported platform` throw at line 24 and presumably needs the same treatment, but I only exercised the bun package, so I left it alone rather than ship an untested change. Say the word and I will mirror it.

`aarch64-unknown-freebsd` is mapped but was not built or tested — drop that line if you would rather not carry an unverified target.

## Context

This came from getting a Bun-based coding agent running on FreeBSD; fff was the first of three native dependencies to need attention, and the only one where the native code itself was already fine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for FreeBSD on x86_64 and ARM64 systems.
  - Added corresponding FreeBSD binary packages for installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->