### PR TITLE
fix: keep grep path constraint when the pinned file exists (#830)

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -5,6 +5,7 @@
  * @-mention autocomplete suggestions to the interactive editor.
  */
 
+import fs from "node:fs";
 import nodePath from "node:path";
 import type {
   ExtensionAPI,
@@ -28,7 +29,7 @@ import { Type, type TSchema } from "@sinclair/typebox";
 import { AuxFinderPool, routePathConstraint } from "./aux-finders";
 import { type FffMode, loadConfig, VALID_MODES } from "./config";
 import { FilePickerFactory } from "./file-picker";
-import { isHomeDir, resolveDbPaths } from "./paths";
+import { HOME_DIR, isHomeDir, resolveDbPaths } from "./paths";
 import { buildQuery } from "./query";
 
 export { SCAN_TIMEOUT_MS } from "./sdk";
@@ -929,7 +930,14 @@ export default function fffExtension(pi: ExtensionAPI) {
         // excluded / out-of-scope directories.
         const lastSeg = params.path?.split(/[\\/]/).pop() ?? "";
         const pathTargetsFile = /\.[a-zA-Z][a-zA-Z0-9]{0,9}$/.test(lastSeg);
-        const fuzzyQuery = pathTargetsFile ? pattern : query;
+        // A pinned file that exists on disk is not a misnamed guess, so widening
+        // past it would answer a different question with repo-wide noise (#830).
+        const pinnedFile =
+          pathTargetsFile && params.path
+            ? resolvePinnedFile(params.path, activeCwd)
+            : null;
+        const dropConstraint = pathTargetsFile && !pinnedFile;
+        const fuzzyQuery = dropConstraint ? pattern : query;
         const fuzzy = picker.grep(fuzzyQuery, {
           mode: "fuzzy",
           smartCase,
@@ -943,8 +951,15 @@ export default function fffExtension(pi: ExtensionAPI) {
         });
 
         if (fuzzy.ok && fuzzy.value.items.length > 0) {
-          fuzzyNotice = `0 exact matches. Maybe you meant this?`;
+          fuzzyNotice = dropConstraint
+            ? `0 exact matches, path constraint dropped (no such file: ${params.path}); results are repo-wide`
+            : `0 exact matches. Maybe you meant this?`;
           result = fuzzy.value;
+        } else if (
+          pinnedFile &&
+          !isIndexedFile(picker, aux ? aux.root : activeCwd, pinnedFile)
+        ) {
+          fuzzyNotice = `${params.path} is not indexed (gitignored or excluded)`;
         }
       }
 
@@ -1334,4 +1349,36 @@ export default function fffExtension(pi: ExtensionAPI) {
       ctx.ui.notify("FFF rescan triggered", "info");
     },
   });
+}
+
+// Absolute path of an existing regular file named by a `path` constraint, or
+// null when the constraint is a glob or points at nothing / a directory.
+function resolvePinnedFile(pathParam: string, cwd: string): string | null {
+  const trimmed = pathParam.trim();
+  if (!trimmed || /[*?[{]/.test(trimmed)) return null;
+  const expanded =
+    trimmed === "~" || trimmed.startsWith("~/")
+      ? nodePath.join(HOME_DIR, trimmed.slice(1))
+      : trimmed;
+
+  try {
+    const abs = nodePath.resolve(cwd, expanded);
+    return fs.statSync(abs).isFile() ? abs : null;
+  } catch {
+    return null;
+  }
+}
+
+// Whether the picker's index holds `absPath`. Runs only on the zero-result path,
+// so the extra index pass never touches a hot query.
+function isIndexedFile(picker: FileFinderApi, root: string, absPath: string): boolean {
+  const rel = nodePath.relative(root, absPath).replaceAll(nodePath.sep, "/");
+  if (!rel || rel.startsWith("../")) return false;
+
+  try {
+    const result = picker.glob(rel, { pageSize: 1 });
+    return result.ok && result.value.items.some((file) => file.relativePath === rel);
+  } catch {
+    return true;
+  }
 }

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -7,6 +7,8 @@ type MockFinder = {
   isDestroyed: boolean;
   waitForScan: ReturnType<typeof mock>;
   mixedSearch: ReturnType<typeof mock>;
+  grep: ReturnType<typeof mock>;
+  glob: ReturnType<typeof mock>;
   getScanProgress: ReturnType<typeof mock>;
   destroy: ReturnType<typeof mock>;
 };
@@ -14,7 +16,16 @@ type MockFinder = {
 const createCalls: unknown[] = [];
 let finders: MockFinder[] = [];
 let mixedSearchImpl: ((query: string, options: unknown) => unknown) | undefined;
+let grepImpl: ((query: string, options: any) => unknown) | undefined;
+let globImpl: ((pattern: string, options: any) => unknown) | undefined;
 let scanProgressImpl: (() => unknown) | undefined;
+
+function emptyGrepResult() {
+  return {
+    ok: true,
+    value: { items: [], totalMatched: 0, totalFiles: 0, nextCursor: null },
+  };
+}
 
 function createMockFinder(): MockFinder {
   return {
@@ -44,6 +55,14 @@ function createMockFinder(): MockFinder {
           totalDirs: 0,
         },
       };
+    }),
+    grep: mock((query: string, options: any) => {
+      if (grepImpl) return grepImpl(query, options);
+      return emptyGrepResult();
+    }),
+    glob: mock((pattern: string, options: any) => {
+      if (globImpl) return globImpl(pattern, options);
+      return { ok: true, value: { items: [], totalMatched: 0, totalFiles: 0 } };
     }),
     destroy: mock(function (this: MockFinder) {
       this.isDestroyed = true;
@@ -203,6 +222,8 @@ beforeEach(() => {
   createCalls.length = 0;
   finders = [];
   mixedSearchImpl = undefined;
+  grepImpl = undefined;
+  globImpl = undefined;
   scanProgressImpl = undefined;
 
   for (const key of CONFIG_ENV_KEYS) delete process.env[key];
@@ -457,6 +478,126 @@ describe("pi-fff $HOME scan warning", () => {
     const setup = await start(undefined, os.homedir());
 
     expect(setup.ctx.ui.notify).not.toHaveBeenCalled();
+    await shutdown(setup);
+  });
+});
+
+// Regression for #830: a path constraint pinning an unindexed file must not be
+// silently dropped, turning the grep into a repo-wide fuzzy search.
+describe("pi-fff grep fuzzy fallback", () => {
+  const grepWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "pi-fff-grep-"));
+  fs.mkdirSync(path.join(grepWorkspace, "node_modules", "react"), { recursive: true });
+  fs.writeFileSync(
+    path.join(grepWorkspace, "node_modules", "react", "package.json"),
+    JSON.stringify({ exports: { "./jsx-runtime": "./jsx-runtime.js" } }),
+  );
+
+  afterAll(() => fs.rmSync(grepWorkspace, { recursive: true, force: true }));
+
+  // Mimics the native picker: the constrained query hits nothing because
+  // node_modules is excluded from the index, an unconstrained one matches
+  // arbitrary frecency-ranked source files.
+  function excludedIndexGrep(query: string) {
+    if (query.includes("node_modules")) return emptyGrepResult();
+    return {
+      ok: true,
+      value: {
+        items: [
+          {
+            relativePath: "src/renderer/App.tsx",
+            lineNumber: 12,
+            lineContent: "  useEffect(() => {",
+          },
+        ],
+        totalMatched: 1,
+        totalFiles: 1,
+        nextCursor: null,
+      },
+    };
+  }
+
+  async function grepTool(cwd: string) {
+    const setup = await start(undefined, cwd);
+    const tool = setup.pi.registerTool.mock.calls
+      .map(([t]) => t)
+      .find((t) => t.name === "grep" || t.name === "ffgrep");
+    expect(tool).toBeDefined();
+    return { setup, tool };
+  }
+
+  test("keeps the constraint when the pinned file exists but is not indexed", async () => {
+    grepImpl = (query) => excludedIndexGrep(query);
+    const { setup, tool } = await grepTool(grepWorkspace);
+
+    const result = await tool.execute("call-1", {
+      pattern: "jsx-runtime",
+      path: "node_modules/react/package.json",
+    });
+
+    const text = result.content[0].text;
+    expect(text).not.toContain("src/renderer/App.tsx");
+    expect(text).toContain("No matches found");
+    expect(text).toContain("not indexed");
+    // Every grep call must have carried the constraint.
+    for (const [query] of finders[0].grep.mock.calls) {
+      expect(query).toContain("node_modules/react/package.json");
+    }
+    await shutdown(setup);
+  });
+
+  test("broadens for a misnamed file but says the constraint was dropped", async () => {
+    grepImpl = (query) => {
+      if (query.includes("does-not-exist.ts")) return emptyGrepResult();
+      return excludedIndexGrep("jsx-runtime");
+    };
+    const { setup, tool } = await grepTool(grepWorkspace);
+
+    const result = await tool.execute("call-2", {
+      pattern: "jsx-runtime",
+      path: "src/does-not-exist.ts",
+    });
+
+    const text = result.content[0].text;
+    expect(text).toContain("src/renderer/App.tsx");
+    expect(text).toContain("path constraint dropped");
+    await shutdown(setup);
+  });
+
+  test("an indexed pinned file with no hits stays a plain miss", async () => {
+    fs.writeFileSync(path.join(grepWorkspace, "package.json"), "{}");
+    grepImpl = () => emptyGrepResult();
+    globImpl = (pattern) => ({
+      ok: true,
+      value: {
+        items: [{ relativePath: pattern, fileName: pattern, gitStatus: "clean" }],
+        totalMatched: 1,
+        totalFiles: 1,
+      },
+    });
+    const { setup, tool } = await grepTool(grepWorkspace);
+
+    const result = await tool.execute("call-3", {
+      pattern: "jsx-runtime",
+      path: "package.json",
+    });
+
+    expect(result.content[0].text).toBe("No matches found");
+    await shutdown(setup);
+  });
+
+  test("directory constraints keep the constrained fuzzy query", async () => {
+    grepImpl = (query) => excludedIndexGrep(query);
+    const { setup, tool } = await grepTool(grepWorkspace);
+
+    const result = await tool.execute("call-4", {
+      pattern: "jsx-runtime",
+      path: "node_modules/react/",
+    });
+
+    expect(result.content[0].text).toContain("No matches found");
+    for (const [query] of finders[0].grep.mock.calls) {
+      expect(query).toContain("node_modules/react/");
+    }
     await shutdown(setup);
   });
 });


### PR DESCRIPTION
Closes #830

## Root cause

`packages/pi-fff/src/index.ts:930-932` decided to drop the `path` constraint from the fuzzy fallback purely from the trailing extension of `params.path`, never checking that the pinned file was reachable in the picker. Since `routePathConstraint` (`packages/pi-fff/src/aux-finders.ts:165`) keeps workspace-relative paths on the workspace finder, and that index excludes `node_modules/**`, every grep pinned there returned 0 exact matches and then re-ran repo-wide with the constraint gone.

## Fix

Widening is now limited to the case the heuristic was written for: a `path` that resolves to nothing on disk (misnamed guess), and the notice says the constraint was dropped. A pinned file that exists keeps its constraint; if it is also absent from the index, the notice states that instead of returning unrelated files.

## Steps to reproduce

```sh
git checkout main && make prepare-bun
mkdir -p /tmp/fff830 && cd /tmp/fff830 && git init -q
printf 'node_modules/\n' > .gitignore
mkdir -p node_modules/react src/renderer
printf '{"name":"react","exports":{"./jsx-runtime":"x"}}' > node_modules/react/package.json
printf 'export const App = () => { useEffect(() => {}, []) }\n' > src/renderer/App.tsx
```

Then, with the checked-out extension loaded (`pi -e packages/pi-fff/src/index.ts -p --no-session ...`), call:

```
ffgrep { pattern: "jsx-runtime", path: "node_modules/react/package.json" }
```

expected — the pinned path is honoured:

```
[node_modules/react/package.json is not indexed (gitignored or excluded)]
No matches found
```

actual on `main` — constraint silently dropped, unrelated file returned:

```
[0 exact matches. Maybe you meant this?]
src/renderer/App.tsx
 12: useEffect(() => {
```

The same three cases are covered deterministically by the new tests in `packages/pi-fff/test/extension.test.ts` (`pi-fff grep fuzzy fallback`); they fail on `main` with exactly the output above and pass here.

## How verified

```
cd packages/pi-fff && bun test test/
83 pass, 0 fail (was 80 pass before the 3 new + 1 control test)
```

Against the real native picker on the fixture above (temporary harness, not committed): `glob("package.json")` returns `package.json`, `glob("node_modules/react/package.json")` returns `[]`, and `ffgrep` with the pinned path yields the `not indexed` message for `jsx-runtime` and `sideEffects` instead of `src/renderer/App.tsx`.

`bunx oxfmt` and `bunx oxlint packages/pi-fff` clean. The extra `glob` pass runs only after an exact grep already returned zero rows, so no hot query gains work.

@dmtrKovalenko one unrelated thing surfaced while verifying: with `path: "node_modules/react/package.json"` and `pattern: "version"`, the *exact* grep still matched the workspace-root `package.json`. That is `normalizePathConstraint` emitting a FilePath constraint that matches on basename, not the fallback, and it lives in the query parser — left alone here.

Automated triage via Gustav. Honk-Honk 🪿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fuzzy search handling for file path constraints.
  * Existing files that are not indexed now retain their path constraint and receive a clear notification.
  * Missing file paths now trigger a repository-wide fuzzy search with an explanation that the constraint was dropped.
  * Directory-based constraints continue to work correctly.

* **Tests**
  * Added coverage for indexed, unindexed, missing, and directory path scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->