### PR TITLE
fix: decouple ffgrep per-file cap from page size (#825)

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -40,6 +40,10 @@ export { SCAN_TIMEOUT_MS } from "./sdk";
 const DEFAULT_GREP_LIMIT = 20;
 const DEFAULT_FIND_LIMIT = 30;
 const GREP_PAGE_SIZE_MAX = 50;
+// Per-file match cap. Must stay decoupled from pageSize: grep cursors advance by
+// file offset, so clamping this to pageSize makes same-file overflow unreachable
+// on later pages (#825). Matches the engine default.
+const GREP_MAX_MATCHES_PER_FILE = 200;
 const GREP_CONTEXT_MAX = 20;
 const GREP_MAX_LINE_LENGTH = 500;
 const MENTION_MAX_RESULTS = 20;
@@ -849,8 +853,9 @@ export default function fffExtension(pi: ExtensionAPI) {
 
       const picker = aux ? aux.finder : await ensureFinder(activeCwd);
       const effectiveLimit = Math.max(1, params.limit ?? DEFAULT_GREP_LIMIT);
-      // pageSize caps TOTAL matches across all files; maxMatchesPerFile alone
-      // only caps per-file, so limit=5 could still return a full SDK page.
+      // pageSize caps TOTAL matches across all files (soft cap: the current file
+      // is always finished first). maxMatchesPerFile stays decoupled at the engine
+      // default so same-file overflow remains reachable via cursor (#825).
       const pageSize = Math.min(effectiveLimit, GREP_PAGE_SIZE_MAX);
       const context = clampContext(params.context);
       const query = aux
@@ -900,7 +905,7 @@ export default function fffExtension(pi: ExtensionAPI) {
       const grepResult = picker.grep(query, {
         mode,
         smartCase,
-        maxMatchesPerFile: pageSize,
+        maxMatchesPerFile: GREP_MAX_MATCHES_PER_FILE,
         pageSize,
         cursor: (params.cursor ? getCursor(params.cursor) : null) ?? null,
         beforeContext: context,
@@ -933,7 +938,7 @@ export default function fffExtension(pi: ExtensionAPI) {
         const fuzzy = picker.grep(fuzzyQuery, {
           mode: "fuzzy",
           smartCase,
-          maxMatchesPerFile: pageSize,
+          maxMatchesPerFile: GREP_MAX_MATCHES_PER_FILE,
           pageSize,
           cursor: null,
           beforeContext: 0,
@@ -1183,7 +1188,7 @@ export default function fffExtension(pi: ExtensionAPI) {
         const grepResult = f.multiGrep({
           patterns: params.patterns,
           constraints: params.constraints,
-          maxMatchesPerFile: pageSize,
+          maxMatchesPerFile: GREP_MAX_MATCHES_PER_FILE,
           pageSize,
           smartCase: true,
           cursor: (params.cursor ? getCursor(params.cursor) : null) ?? null,

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -7,6 +7,7 @@ type MockFinder = {
   isDestroyed: boolean;
   waitForScan: ReturnType<typeof mock>;
   mixedSearch: ReturnType<typeof mock>;
+  grep: ReturnType<typeof mock>;
   getScanProgress: ReturnType<typeof mock>;
   destroy: ReturnType<typeof mock>;
 };
@@ -14,6 +15,7 @@ type MockFinder = {
 const createCalls: unknown[] = [];
 let finders: MockFinder[] = [];
 let mixedSearchImpl: ((query: string, options: unknown) => unknown) | undefined;
+let grepImpl: ((query: string, options: unknown) => unknown) | undefined;
 let scanProgressImpl: (() => unknown) | undefined;
 
 function createMockFinder(): MockFinder {
@@ -42,6 +44,20 @@ function createMockFinder(): MockFinder {
           totalMatched: 0,
           totalFiles: 0,
           totalDirs: 0,
+        },
+      };
+    }),
+    grep: mock((query: string, options: unknown) => {
+      if (grepImpl) return grepImpl(query, options);
+      return {
+        ok: true,
+        value: {
+          items: [],
+          totalMatched: 0,
+          totalFiles: 0,
+          totalFilesSearched: 0,
+          filteredFileCount: 0,
+          nextCursor: null,
         },
       };
     }),
@@ -203,6 +219,7 @@ beforeEach(() => {
   createCalls.length = 0;
   finders = [];
   mixedSearchImpl = undefined;
+  grepImpl = undefined;
   scanProgressImpl = undefined;
 
   for (const key of CONFIG_ENV_KEYS) delete process.env[key];
@@ -645,5 +662,44 @@ describe("pi-fff autocomplete registration", () => {
     expect(shouldTrigger).toBe(false);
     expect(current.applyCompletion).toHaveBeenCalledTimes(1);
     expect(current.shouldTriggerFileCompletion).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ffgrep per-file cap (#825)", () => {
+  function grepTool(setup: { pi: { registerTool: ReturnType<typeof mock> } }) {
+    const tool = setup.pi.registerTool.mock.calls
+      .map(([t]) => t)
+      .find((t) => t.name === "ffgrep" || t.name === "grep");
+    expect(tool).toBeDefined();
+    return tool;
+  }
+
+  // Grep cursors advance by file offset, so maxMatchesPerFile must NOT be clamped
+  // to pageSize — otherwise same-file overflow is unreachable on later pages.
+  test("passes a per-file cap decoupled from pageSize", async () => {
+    let captured: any;
+    grepImpl = (_query, options) => {
+      captured = options;
+      return {
+        ok: true,
+        value: {
+          items: [],
+          totalMatched: 0,
+          totalFiles: 0,
+          totalFilesSearched: 0,
+          filteredFileCount: 0,
+          nextCursor: null,
+        },
+      };
+    };
+
+    const setup = await start("tools-and-ui");
+    const tool = grepTool(setup);
+    await tool.execute("call-1", { pattern: "TODO", limit: 20 }, abortOptions().signal);
+
+    expect(captured).toBeDefined();
+    expect(captured.pageSize).toBe(20);
+    expect(captured.maxMatchesPerFile).toBe(200);
+    expect(captured.maxMatchesPerFile).toBeGreaterThan(captured.pageSize);
   });
 });


### PR DESCRIPTION
Closes #825

## Root cause
`packages/pi-fff/src/index.ts` passed `maxMatchesPerFile: pageSize` for grep (`:908`, `:941`) and multi-grep (`:1191`). The engine's grep cursor is a file offset (`crates/fff-core/src/grep/types.rs:87-89`, `next_file_offset`), and `maxMatchesPerFile` caps per-file matches (`types.rs:84`). Clamping the per-file cap down to the page size means once a file's first `pageSize` matches are collected, the next cursor advances past that file, so its remaining matches are unreachable on every later page. `page_limit` is only a soft cap that finishes the current file (`types.rs:209-215`), so the two limits must stay decoupled.

## Fix
Add `GREP_MAX_MATCHES_PER_FILE = 200` (the engine default) and pass it as `maxMatchesPerFile` at all three grep call sites. `pageSize` still bounds total matches per page; the per-file cap no longer discards same-file overflow.

## Steps to reproduce
Build the native lib and prepare the bun package on pre-fix `main`:

```sh
make prepare-bun
```

Save as `packages/fff-bun/repro825.mjs` (exercises the exact options pi-fff passes to the engine):

```js
import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
import { join } from "node:path";
import { tmpdir } from "node:os";
import { FileFinder } from "./src/index.ts";

const root = mkdtempSync(join(tmpdir(), "fff825-"));
mkdirSync(join(root, "src"), { recursive: true });
writeFileSync(join(root, "noise.ts"),
  Array.from({ length: 30 }, (_, i) => `TODO fix ${String(i + 1).padStart(2, "0")}`).join("\n") + "\n");
writeFileSync(join(root, "src/app.ts"), "TODO app\n");
writeFileSync(join(root, "src/utils.ts"), "TODO utils\n");
writeFileSync(join(root, "README.md"), "TODO readme\n");

const finder = FileFinder.create({ basePath: root });
await finder.value.waitForIndexReady(5000);

function walk(perFile, page) {
  const got = []; let cursor = null; const pages = [];
  for (let i = 0; i < 10; i++) {
    const r = finder.value.grep("TODO", { mode: "plain", smartCase: true, maxMatchesPerFile: perFile, pageSize: page, cursor });
    got.push(...r.value.items.map((m) => m.lineContent.trim()));
    pages.push(r.value.items.length);
    cursor = r.value.nextCursor;
    if (!cursor) break;
  }
  return { got, pages };
}
const expected = [
  ...Array.from({ length: 30 }, (_, i) => `TODO fix ${String(i + 1).padStart(2, "0")}`),
  "TODO app", "TODO utils", "TODO readme",
];
const miss = (r) => expected.filter((e) => !r.got.includes(e));
const buggy = walk(20, 20);   // current pi-fff: maxMatchesPerFile === pageSize
const fixed = walk(200, 20);  // decoupled
console.log(JSON.stringify({
  current_pi_fff: { pages: buggy.pages, retrieved: buggy.got.length, missing: miss(buggy) },
  decoupled_cap:  { pages: fixed.pages, retrieved: fixed.got.length, missing: miss(fixed) },
}, null, 2));
rmSync(root, { recursive: true, force: true });
```

Run: `cd packages/fff-bun && bun repro825.mjs`

Expected: all 33 matches retrieved by walking cursors to exhaustion.
Actual (pre-fix, `maxMatchesPerFile === pageSize === 20`):

```json
{
  "current_pi_fff": { "pages": [21, 2], "retrieved": 23,
    "missing": ["TODO fix 21","TODO fix 22","TODO fix 23","TODO fix 24","TODO fix 25","TODO fix 26","TODO fix 27","TODO fix 28","TODO fix 29","TODO fix 30"] },
  "decoupled_cap":  { "pages": [31, 2], "retrieved": 33, "missing": [] }
}
```

## How verified
- SDK repro above: decoupled cap retrieves all 33; clamped cap drops matches 21-30.
- Added regression test `ffgrep per-file cap (#825)` asserting the tool passes `maxMatchesPerFile: 200` decoupled from `pageSize`. `cd packages/pi-fff && bun test test/` → `80 pass, 0 fail`.
- `oxfmt --check` and `oxlint` clean on both changed files.

Note: files with more than `GREP_MAX_MATCHES_PER_FILE` (200) matches still truncate — that is the deeper file-offset limitation tracked in #365, out of scope here.

Automated triage via Gustav. Honk-Honk 🪿


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grep pagination so searches can continue retrieving additional matches from the same file.
  * Per-file result limits are now independent of the page size, preventing relevant matches from being truncated prematurely.
* **Tests**
  * Added coverage to verify the updated grep result-limit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->