### PR TITLE
fix(pi-fff): avoid blocking startup on initial scan

### DIFF
--- a/packages/pi-fff/src/file-picker.ts
+++ b/packages/pi-fff/src/file-picker.ts
@@ -1,5 +1,5 @@
 import type { FileFinderApi, InitOptions, Result } from "@ff-labs/fff-node";
-import { type FileFinderStatic, loadSdk, SCAN_TIMEOUT_MS } from "./sdk";
+import { type FileFinderStatic, loadSdk } from "./sdk";
 
 export interface PickerOptions {
   basePath: string;
@@ -30,7 +30,7 @@ export class FilePickerFactory {
     return this.dbDisabled;
   }
 
-  /** Opens a scanned, ready-to-use picker. Throws if it cannot be created. */
+  /** Opens a picker that scans in the background. Throws if it cannot be created. */
   async create(options: PickerOptions): Promise<FileFinderApi> {
     const { FileFinder } = await loadSdk();
     const result = this.openWithDbFallback(FileFinder, options);
@@ -41,9 +41,6 @@ export class FilePickerFactory {
       );
     }
 
-    // waitForScan() also resolves on timeout, so this bounds startup rather
-    // than guaranteeing a complete index.
-    await result.value.waitForScan(SCAN_TIMEOUT_MS);
     return result.value;
   }
 

--- a/packages/pi-fff/test/file-picker.test.ts
+++ b/packages/pi-fff/test/file-picker.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const waitForScan = mock(async () => undefined);
+const finder = { waitForScan };
+const finderModule = {
+  FileFinder: {
+    create: mock(() => ({ ok: true, value: finder })),
+  },
+};
+
+mock.module("@ff-labs/fff-node", () => finderModule);
+mock.module("@ff-labs/fff-bun", () => finderModule);
+
+const { FilePickerFactory } = await import("../src/file-picker");
+
+describe("FilePickerFactory", () => {
+  test("returns the picker without waiting for its initial scan", async () => {
+    const factory = new FilePickerFactory({
+      frecencyDbPath: "/dbs/frecency",
+      historyDbPath: "/dbs/history",
+    });
+
+    const result = await factory.create({ basePath: "/workspace" });
+
+    expect(result).toBeDefined();
+    expect(waitForScan).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- return the native finder immediately after successful creation
- let the initial filesystem scan continue in the background
- add regression coverage preventing `waitForScan()` from returning to the shared factory path

## Why

Pi emits `session_shutdown` followed by `session_start` during `/reload`. The shared picker factory currently waits up to 15 seconds for the initial scan, so every reload can block on a fresh traversal.

The finder is usable while scanning; searches may temporarily return partial results. This trade-off avoids blocking Pi startup and reload while preserving scan progress reporting and lifecycle cleanup.

## Verification

- `cd packages/pi-fff && bun run typecheck`
- `cd packages/pi-fff && bun test test/` — 81 tests passed
- focused live Pi reload A/B: stock 3.24 s; patched 30–114 ms
- immediate search while `isScanning` was true returned a valid result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * File pickers are now available immediately while scanning continues in the background.
  * Reduced startup waiting time when creating a file picker.

* **Tests**
  * Added coverage confirming picker creation does not wait for the initial scan to finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->