### PR TITLE
docs: fix Node type reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ const rustFiles = finder.value.glob("**/*.rs", { pageSize: 100 });
 finder.value.destroy();
 ```
 
-Every method returns a `Result<T>` (`{ ok: true, value } | { ok: false, error }`). Full type reference: [`packages/fff-node/src/types.ts`](./packages/fff-node/src/types.ts).
+Every method returns a `Result<T>` (`{ ok: true, value } | { ok: false, error }`). Full type reference: [`packages/fff-node/src/fff-api.ts`](./packages/fff-node/src/fff-api.ts).
 
 </details>
 


### PR DESCRIPTION
## Summary
- update the README Node wrapper type-reference link to point at the existing fff-api.ts file
- remove the stale link to packages/fff-node/src/types.ts, which is not present in the repository

## Verification
- git diff --check
- checked all relative Markdown links resolve with a local script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Node and Bun SDK documentation to link to the correct full type reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->