### PR TITLE
fix(fff-mcp): omit git:clean from find_files output

### DIFF
--- a/crates/fff-mcp/src/output.rs
+++ b/crates/fff-mcp/src/output.rs
@@ -21,9 +21,11 @@ fn frecency_word(score: i32) -> Option<&'static str> {
 }
 
 pub fn file_suffix(git_status: Option<git2::Status>, frecency_score: i32) -> String {
+    // `clean` is the default state of nearly every file: annotating it burns
+    // context without adding signal. Only exceptional git state is surfaced.
     match (
         frecency_word(frecency_score),
-        format_git_status_opt(git_status),
+        format_git_status_opt(git_status).filter(|status| *status != "clean"),
     ) {
         (Some(f), Some(g)) => format!(" - {f} git:{g}"),
         (Some(f), None) => format!(" - {f}"),
@@ -544,6 +546,27 @@ fn collect_file_preview<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn suffix_omits_clean_git_status() {
+        assert_eq!(file_suffix(None, 0), "");
+        assert_eq!(file_suffix(Some(git2::Status::CURRENT), 0), "");
+        assert_eq!(file_suffix(Some(git2::Status::empty()), 0), "");
+        assert_eq!(file_suffix(None, 120), " - hot");
+    }
+
+    #[test]
+    fn suffix_keeps_dirty_git_status() {
+        assert_eq!(
+            file_suffix(Some(git2::Status::WT_MODIFIED), 0),
+            " git:modified"
+        );
+        assert_eq!(file_suffix(Some(git2::Status::WT_NEW), 0), " git:untracked");
+        assert_eq!(
+            file_suffix(Some(git2::Status::INDEX_MODIFIED), 60),
+            " - warm git:staged_modified"
+        );
+    }
 
     #[test]
     fn trunc_strips_trailing_whitespace() {


### PR DESCRIPTION
Closes #844

## Root cause

`format_git_status_opt(None)` returns `Some("clean")` (`crates/fff-core/src/git.rs:142-144`), so `file_suffix()` (`crates/fff-mcp/src/output.rs:23`) materialized the default git state as ` git:clean` on every `find_files` result line (`crates/fff-mcp/src/server.rs:537`). `pi-fff` already suppresses it (`packages/pi-fff/src/index.ts:160`).

## Fix

One filter in the MCP presentation layer only. Core keeps the full status, so `git:modified` / `git:untracked` query constraints are unaffected. Dirty and staged states still render.

```rust
format_git_status_opt(git_status).filter(|status| *status != "clean"),
```

## Steps to reproduce

```sh
cargo build --release -p fff-mcp

# fixture: 8 files, one modified, one staged, one untracked
rm -rf /tmp/fff-844 && mkdir -p /tmp/fff-844/src && cd /tmp/fff-844
git init -q . && git config user.email b@b && git config user.name b
for n in a b c d e f g h; do printf 'export const %s = 1\n' $n > src/svc_$n.ts; done
git add -A && git commit -qm init
printf 'export const a = 2\n' > src/svc_a.ts
printf 'export const b = 3\n' > src/svc_b.ts && git add src/svc_b.ts
printf 'export const n = 1\n' > src/svc_new.ts

# then call find_files(query="svc") over stdio against this dir
```

Expected (this PR) vs actual on pre-fix `main`:

```text
  expected                         actual (main)
  src/svc_a.ts git:modified        src/svc_a.ts git:modified
  src/svc_b.ts git:staged_modified src/svc_b.ts git:staged_modified
  src/svc_new.ts git:untracked     src/svc_new.ts git:untracked
  src/svc_d.ts                     src/svc_d.ts git:clean
  src/svc_e.ts                     src/svc_e.ts git:clean
  ...                              ...
```

## How verified

- `cargo test -p fff-mcp` green, plus 2 new unit tests in `output.rs` pinning that `clean`/`CURRENT`/empty/`None` produce no tag while dirty + staged states and frecency words survive.
- `cargo clippy -p fff-mcp` clean.
- Live stdio probe of the built binary on the fixture above — output matches the table.
- `scripts/benchmark-claude.sh` A/B, baseline binary vs this one, fff arm, 11 concepts each: task completion **10/11 in both arms**, 0 errors in both. Concept 2 fails in both (its target path no longer exists in the corpus — stale ground truth, unrelated). Cost/turn deltas are pure noise (turn-count variance swamps the change): $1.8214 baseline vs $1.7151 patched.
- Context saved where it applies: on a 20-result `find_files` page over `chromium`, ` git:clean` was 200 of ~1600 chars, i.e. **-12.4%** of payload. The eval suite itself only calls `find_files` 3-6 times across 11 concepts (grep dominates: 21 calls), so suite-level byte savings are small — the win shows up in find_files-heavy sessions.

Automated triage via Gustav. Honk-Honk 🪿


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clean files no longer display an unnecessary Git status annotation.
  * Git status indicators continue to appear for modified, untracked, and staged files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->