### PR TITLE
fix(fff-mcp): apply --max-cached-files as a cap, not a repo size (#847)

### DIFF
--- a/crates/fff-core/src/types.rs
+++ b/crates/fff-core/src/types.rs
@@ -966,6 +966,16 @@ impl ContentCacheBudget {
         }
     }
 
+    /// Apply an explicit file cap verbatim, keeping the default byte caps.
+    /// `0` means no persistent caching at all — files stay searchable through
+    /// the temporary mmaps that grep releases after each call.
+    pub fn with_max_files(max_files: usize) -> Self {
+        Self {
+            max_files,
+            ..Self::default()
+        }
+    }
+
     /// Build a budget from caller-supplied overrides.
     ///
     /// Each argument is a cap; `0` means "use the library default for that
@@ -1000,5 +1010,40 @@ impl ContentCacheBudget {
 impl Default for ContentCacheBudget {
     fn default() -> Self {
         Self::new_for_repo(30_000)
+    }
+}
+
+#[cfg(test)]
+mod content_cache_budget_tests {
+    use super::*;
+
+    #[test]
+    fn with_max_files_applies_the_cap_verbatim() {
+        // regression: the cap used to be routed through new_for_repo, which
+        // read it as a repo file count and bucketed 2000 up to 30_000
+        assert_eq!(ContentCacheBudget::with_max_files(2000).max_files, 2000);
+        assert_eq!(ContentCacheBudget::with_max_files(7).max_files, 7);
+        assert_eq!(
+            ContentCacheBudget::with_max_files(1_000_000).max_files,
+            1_000_000
+        );
+    }
+
+    #[test]
+    fn with_max_files_zero_disables_persistent_caching_but_keeps_grep() {
+        let budget = ContentCacheBudget::with_max_files(0);
+        assert_eq!(budget.max_files, 0);
+        assert!(budget.is_exhausted());
+        // temporary-mmap grep is gated on max_file_size, which must survive
+        assert_eq!(budget.max_file_size, MAX_FFFILE_SIZE);
+        assert!(budget.max_bytes > 0);
+    }
+
+    #[test]
+    fn with_max_files_keeps_default_byte_caps() {
+        let budget = ContentCacheBudget::with_max_files(2000);
+        let default = ContentCacheBudget::default();
+        assert_eq!(budget.max_bytes, default.max_bytes);
+        assert_eq!(budget.max_file_size, default.max_file_size);
     }
 }

--- a/crates/fff-core/tests/explicit_cache_budget.rs
+++ b/crates/fff-core/tests/explicit_cache_budget.rs
@@ -1,0 +1,56 @@
+//! Regression test for https://github.com/dmtrKovalenko/fff/issues/847
+//!
+//! An explicit `--max-cached-files` cap must reach the picker verbatim and
+//! survive the initial scan, which otherwise auto-sizes the budget.
+
+use std::fs;
+
+use fff_search::file_picker::FilePicker;
+use fff_search::{ContentCacheBudget, FilePickerOptions};
+use tempfile::TempDir;
+
+#[test]
+fn explicit_cap_reaches_the_picker_and_survives_the_scan() {
+    let dir = TempDir::new().unwrap();
+    for i in 0..8 {
+        fs::write(dir.path().join(format!("f{i}.txt")), "x".repeat(32 * 1024)).unwrap();
+    }
+
+    let mut picker = FilePicker::new(FilePickerOptions {
+        base_path: dir.path().to_string_lossy().to_string(),
+        watch: false,
+        cache_budget: Some(ContentCacheBudget::with_max_files(2)),
+        ..Default::default()
+    })
+    .expect("failed to create FilePicker");
+
+    assert!(picker.has_explicit_cache_budget());
+    assert_eq!(picker.cache_budget().max_files, 2);
+
+    picker.collect_files().expect("failed to collect files");
+
+    // 8 files would otherwise bucket into the 30_000 heuristic
+    assert_eq!(picker.cache_budget().max_files, 2);
+    assert_eq!(
+        picker.cache_budget().max_file_size,
+        ContentCacheBudget::default().max_file_size
+    );
+}
+
+#[test]
+fn zero_cap_keeps_the_budget_exhausted_after_the_scan() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "x".repeat(32 * 1024)).unwrap();
+
+    let mut picker = FilePicker::new(FilePickerOptions {
+        base_path: dir.path().to_string_lossy().to_string(),
+        watch: false,
+        cache_budget: Some(ContentCacheBudget::with_max_files(0)),
+        ..Default::default()
+    })
+    .expect("failed to create FilePicker");
+    picker.collect_files().expect("failed to collect files");
+
+    assert_eq!(picker.cache_budget().max_files, 0);
+    assert!(picker.cache_budget().is_exhausted());
+}

--- a/crates/fff-mcp/src/main.rs
+++ b/crates/fff-mcp/src/main.rs
@@ -154,7 +154,8 @@ pub(crate) struct Args {
 
     /// Maximum number of files whose content is kept persistently in memory.
     /// Files beyond this limit are still searchable via temporary mmaps that
-    /// are released after each grep. Defaults to 30 000.
+    /// are released after each grep. `0` disables persistent caching entirely.
+    /// Unset: auto-sized from the scanned file count.
     /// Also settable via the FFF_MAX_CACHED_FILES environment variable.
     #[arg(long = "max-cached-files", env = "FFF_MAX_CACHED_FILES")]
     max_cached_files: Option<usize>,
@@ -347,7 +348,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             mode: FFFMode::Ai,
             cache_budget: args
                 .max_cached_files
-                .map(fff::ContentCacheBudget::new_for_repo),
+                .map(fff::ContentCacheBudget::with_max_files),
             follow_symlinks: args.follow_symlinks,
             enable_home_dir_scanning: args.enable_home_scan,
             enable_fs_root_scanning: args.enable_root_scan,


### PR DESCRIPTION
Closes #847

Scope: item 1 only. Items 2 and 3 are confirmed but need a policy decision (see the [triage comment](https://github.com/dmtrKovalenko/fff/issues/847#issuecomment-5552249472)); item 4 is already fixed on main.

## Root cause

`--max-cached-files` / `FFF_MAX_CACHED_FILES` was passed to `ContentCacheBudget::new_for_repo` (`crates/fff-mcp/src/main.rs:349-350`), which interprets its argument as the *indexed file count* and returns a bucketed heuristic (`crates/fff-core/src/types.rs:943-967`). Any value `<= 10_000` fell into the last bucket and produced `max_files = 30_000`, so the explicit cap was silently discarded. `from_overrides` already exists for this and is used correctly by fff-c and fff-python — only fff-mcp was miswired.

## Fix

Added `ContentCacheBudget::with_max_files`, which applies the supplied cap verbatim and inherits the default byte caps, and routed the CLI/env value through it. `0` now means no persistent caching, with `max_file_size` left intact so grep still works through the temporary mmaps it releases after each call. `from_overrides` is unusable here because it maps `0` to "auto-size", which is not what an explicit `--max-cached-files 0` asks for.

## Steps to reproduce

On pre-fix `main` (d84c0a1). The flag has no runtime observability, so the deterministic path is the constructor fff-mcp calls with the user's value:

```sh
git checkout d84c0a10cd5ea23285cb5575fa90179f51710f99
cat >> crates/fff-core/src/types.rs <<'RUST'
#[cfg(test)]
mod cache_budget_repro {
    use super::ContentCacheBudget;
    #[test]
    fn explicit_cap_is_ignored() {
        // fff-mcp passes --max-cached-files straight into new_for_repo
        assert_eq!(ContentCacheBudget::new_for_repo(2000).max_files, 2000);
    }
}
RUST
cargo test -p fff-search --lib cache_budget_repro
```

Expected: pass — `--max-cached-files 2000` caps the persistent cache at 2000 files.

Actual:

```
thread 'types::cache_budget_repro::explicit_cap_is_ignored' panicked at crates/fff-core/src/types.rs:1014:9:
assertion `left == right` failed
  left: 30000
 right: 2000
test result: FAILED. 0 passed; 1 failed
```

`git checkout crates/fff-core/src/types.rs` to clean up.

## How verified

`crates/fff-core/tests/explicit_cache_budget.rs` covers the end-to-end path — the explicit cap reaches the picker and survives `collect_files()`, which otherwise auto-sizes the budget at `crates/fff-core/src/file_picker.rs:1021`.

```
cargo test -p fff-search --lib content_cache_budget_tests
  test result: ok. 3 passed; 0 failed

cargo test -p fff-search --no-default-features --features zlob --test explicit_cache_budget
  test result: ok. 2 passed; 0 failed

cargo clippy --workspace --no-default-features --features zlob -- -D warnings
  Finished, no warnings

cargo fmt --all -- --check
  clean
```

`make test-rust` fails locally on 6 watcher targets (`dir_index_consistency_test`, `fs_delete_handler_test`, `new_directory_watcher_test`, `rescan_regression`, `watch_subscription_test`, `watcher_stop_under_lock`) with `watcher did not install`. Verified identical on stashed `main` — pre-existing local FSEvents issue, not this change. Every non-watcher target passes: 12 / 5 / 22 / 2 / 88 / 162 / 17 / 4.

Automated triage via Gustav. Honk-Honk 🪿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `--max-cached-files` option now applies the specified file limit exactly.
  - Setting the limit to `0` disables persistent content caching.
  - When omitted, the cache limit is automatically sized based on the number of scanned files.
  - Default maximum cached file size behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->