### PR TITLE
fix(pi-fff): preserve FFF tool renderers across reload

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -637,30 +637,71 @@ export default function fffExtension(pi: ExtensionAPI) {
   };
 
   const pendingTools: (() => string)[] = [];
+  const registeredToolNames = new Set<string>();
+  // A renderer is attached to a concrete registered name. Keep that name outside
+  // row state so old fffgrep rows retain their title after mode changes to override.
+  const renderToolNames = new WeakMap<object, string>();
   let toolsRegistered = false;
+
+  function getRenderToolName(context: object, fallback: string): string {
+    return renderToolNames.get(context) ?? fallback;
+  }
+
+  function registerTool<TParams extends TSchema, TDetails = unknown, TState = any>(
+    resolveName: () => string,
+    definition: PendingToolDefinition<TParams, TDetails, TState>,
+  ): string {
+    const resolvedName = resolveName();
+    if (registeredToolNames.has(resolvedName)) return resolvedName;
+
+    const { promptGuidelines, renderCall, ...tool } = definition;
+    pi.registerTool({
+      ...tool,
+      name: resolvedName,
+      label: resolvedName,
+      promptGuidelines: promptGuidelines?.(toolNames),
+      renderCall: renderCall
+        ? (args, theme, context) => {
+            renderToolNames.set(context, resolvedName);
+            return renderCall(args, theme, context);
+          }
+        : undefined,
+    });
+    registeredToolNames.add(resolvedName);
+    return resolvedName;
+  }
 
   function queueTool<TParams extends TSchema, TDetails = unknown, TState = any>(
     resolveName: () => string,
     definition: PendingToolDefinition<TParams, TDetails, TState>,
   ): void {
-    pendingTools.push(() => {
-      const { promptGuidelines, ...tool } = definition;
-      const resolvedName = resolveName();
-      pi.registerTool({
-        ...tool,
-        name: resolvedName,
-        label: resolvedName,
-        promptGuidelines: promptGuidelines?.(toolNames),
-      });
-      return resolvedName;
-    });
+    pendingTools.push(() => registerTool(resolveName, definition));
+
+    // Pi restores historical tool rows before session_start. Register the
+    // FFF-named tools now so their renderers resolve. Pi activates every
+    // newly registered tool, so registerPendingTools prunes the names the
+    // final mode did not select.
+    registerTool(resolveName, definition);
   }
 
   function registerPendingTools(): void {
     if (toolsRegistered) return;
 
     const registeredNames = pendingTools.map((register) => register());
-    pi.setActiveTools([...new Set([...pi.getActiveTools(), ...registeredNames])]);
+    const finalNames = new Set(registeredNames);
+    // Pi activates tools on every registerTool call, so the early FFF
+    // registrations above are active by now. Drop the ones the final mode
+    // did not select (override: ffgrep/fffind). Only names this extension
+    // registered are candidates, so builtin tools sharing a name are safe.
+    const staleNames = new Set(
+      [...registeredToolNames].filter((name) => !finalNames.has(name)),
+    );
+    pi.setActiveTools([
+      ...new Set([
+        ...pi.getActiveTools().filter((name) => !staleNames.has(name)),
+        ...registeredNames,
+      ]),
+    ]);
     toolsRegistered = true;
   }
 
@@ -997,7 +1038,7 @@ export default function fffExtension(pi: ExtensionAPI) {
       const pattern = args?.pattern ?? "";
       const path = args?.path ?? ".";
       let content =
-        theme.fg("toolTitle", theme.bold(toolNames.grep)) +
+        theme.fg("toolTitle", theme.bold(getRenderToolName(context, toolNames.grep))) +
         " " +
         theme.fg("accent", `/${pattern}/`) +
         theme.fg("toolOutput", ` in ${path}`);
@@ -1140,7 +1181,7 @@ export default function fffExtension(pi: ExtensionAPI) {
       const pattern = args?.pattern ?? "";
       const path = args?.path ?? ".";
       let content =
-        theme.fg("toolTitle", theme.bold(toolNames.find)) +
+        theme.fg("toolTitle", theme.bold(getRenderToolName(context, toolNames.find))) +
         " " +
         theme.fg("accent", pattern) +
         theme.fg("toolOutput", ` in ${path}`);
@@ -1244,7 +1285,10 @@ export default function fffExtension(pi: ExtensionAPI) {
         const patterns = args?.patterns ?? [];
         const constraints = args?.constraints;
         let content =
-          theme.fg("toolTitle", theme.bold(toolNames.multiGrep)) +
+          theme.fg(
+            "toolTitle",
+            theme.bold(getRenderToolName(context, toolNames.multiGrep)),
+          ) +
           " " +
           theme.fg("accent", patterns.map((p: string) => `"${p}"`).join(", "));
         if (constraints) content += theme.fg("toolOutput", ` (${constraints})`);

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -251,9 +251,12 @@ describe("pi-fff global config", () => {
     const setup = await start();
     const toolNames = setup.pi.registerTool.mock.calls.map(([tool]) => tool.name);
 
-    expect(toolNames).toContain("grep");
-    expect(toolNames).toContain("find");
-    expect(toolNames).not.toContain("ffgrep");
+    expect(toolNames).toEqual(
+      expect.arrayContaining(["ffgrep", "fffind", "grep", "find"]),
+    );
+    expect(setup.pi.setActiveTools).toHaveBeenLastCalledWith(
+      expect.not.arrayContaining(["ffgrep", "fffind"]),
+    );
     expect(createCalls[0]).toEqual({
       basePath: "/tmp/workspace",
       frecencyDbPath: "/config/frecency",
@@ -320,9 +323,12 @@ describe("pi-fff global config", () => {
     const setup = await start("invalid-flag-mode");
     const toolNames = setup.pi.registerTool.mock.calls.map(([tool]) => tool.name);
 
-    expect(toolNames).toContain("grep");
-    expect(toolNames).toContain("find");
-    expect(toolNames).not.toContain("ffgrep");
+    expect(toolNames).toEqual(
+      expect.arrayContaining(["ffgrep", "fffind", "grep", "find"]),
+    );
+    expect(setup.pi.setActiveTools).toHaveBeenLastCalledWith(
+      expect.not.arrayContaining(["ffgrep", "fffind"]),
+    );
     await shutdown(setup);
   });
 });
@@ -332,7 +338,7 @@ function writeConfig(config: Record<string, unknown>): void {
 }
 
 describe("pi-fff session mode", () => {
-  test("registers tools only after restoring the saved mode", async () => {
+  test("pre-registers FFF renderers before restoring the saved mode", async () => {
     const setup = createPi("tools-and-ui");
     const ctx = createContext();
     ctx.sessionManager.getEntries.mockReturnValue([
@@ -340,19 +346,42 @@ describe("pi-fff session mode", () => {
     ]);
     fffExtension(setup.pi as any);
 
-    expect(setup.pi.registerTool).not.toHaveBeenCalled();
+    expect(setup.pi.registerTool.mock.calls.map(([tool]) => tool.name)).toEqual([
+      "ffgrep",
+      "fffind",
+    ]);
+    expect(setup.pi.setActiveTools).not.toHaveBeenCalled();
     await setup.events.get("session_start")?.({ reason: "startup" }, ctx);
 
     const tools = setup.pi.registerTool.mock.calls.map(([tool]) => tool);
     const toolNames = tools.map((tool) => tool.name);
-    expect(toolNames).toContain("grep");
-    expect(toolNames).toContain("find");
-    expect(toolNames).not.toContain("ffgrep");
-    expect(toolNames).not.toContain("fffind");
-    const grepTool = tools.find((tool) => tool.name === "grep");
-    expect(grepTool.promptGuidelines[0].startsWith("grep:")).toBe(true);
+    expect(toolNames).toEqual(
+      expect.arrayContaining(["ffgrep", "fffind", "grep", "find"]),
+    );
+    const historicalGrep = tools.find((tool) => tool.name === "ffgrep");
+    const activeGrep = tools.find((tool) => tool.name === "grep");
+    const theme = {
+      bold: (text: string) => text,
+      fg: (_color: string, text: string) => text,
+    };
+    const historicalCall = historicalGrep.renderCall(
+      { pattern: "TODO", path: "." },
+      theme,
+      { state: {}, invalidate: mock(() => undefined), isError: false },
+    );
+    const activeCall = activeGrep.renderCall({ pattern: "TODO", path: "." }, theme, {
+      state: {},
+      invalidate: mock(() => undefined),
+      isError: false,
+    });
+    expect(historicalCall.text).toBe("ffgrep /TODO/ in .");
+    expect(activeCall.text).toBe("grep /TODO/ in .");
+    expect(activeGrep.promptGuidelines[0].startsWith("grep:")).toBe(true);
     expect(setup.pi.setActiveTools).toHaveBeenCalledWith(
       expect.arrayContaining(["read", "grep", "find"]),
+    );
+    expect(setup.pi.setActiveTools).toHaveBeenLastCalledWith(
+      expect.not.arrayContaining(["ffgrep", "fffind"]),
     );
 
     await setup.commands.get("fff-mode").handler("", ctx);
@@ -363,17 +392,47 @@ describe("pi-fff session mode", () => {
     await shutdown(setup);
   });
 
+  test("prunes auto-activated FFF names when override is the final mode", async () => {
+    const setup = createPi("tools-and-ui");
+    const ctx = createContext();
+    ctx.sessionManager.getEntries.mockReturnValue([
+      { type: "custom", customType: "fff-mode", data: { mode: "override" } },
+    ]);
+    fffExtension(setup.pi as any);
+
+    // Pi core activates every newly registered tool, so the early FFF
+    // registrations are active by the time session_start runs.
+    setup.pi.getActiveTools.mockReturnValue(["read", "ffgrep", "fffind"]);
+    await setup.events.get("session_start")?.({ reason: "startup" }, ctx);
+
+    expect(setup.pi.setActiveTools).toHaveBeenLastCalledWith(
+      expect.arrayContaining(["read", "grep", "find"]),
+    );
+    expect(setup.pi.setActiveTools).toHaveBeenLastCalledWith(
+      expect.not.arrayContaining(["ffgrep", "fffind"]),
+    );
+    await shutdown(setup);
+  });
+
   test("registers tools before an unbound SDK session's first agent turn", async () => {
     const setup = createPi("override");
     const ctx = createContext();
     fffExtension(setup.pi as any);
 
-    expect(setup.pi.registerTool).not.toHaveBeenCalled();
+    expect(setup.pi.registerTool.mock.calls.map(([tool]) => tool.name)).toEqual([
+      "ffgrep",
+      "fffind",
+    ]);
+    expect(setup.pi.setActiveTools).not.toHaveBeenCalled();
     await setup.events.get("before_agent_start")?.({}, ctx);
 
     const toolNames = setup.pi.registerTool.mock.calls.map(([tool]) => tool.name);
-    expect(toolNames).toContain("grep");
-    expect(toolNames).toContain("find");
+    expect(toolNames).toEqual(
+      expect.arrayContaining(["ffgrep", "fffind", "grep", "find"]),
+    );
+    expect(setup.pi.setActiveTools).toHaveBeenLastCalledWith(
+      expect.not.arrayContaining(["ffgrep", "fffind"]),
+    );
     expect(createCalls).toHaveLength(0);
     await shutdown(setup);
   });


### PR DESCRIPTION
# Title

fix(pi-fff): preserve FFF tool renderers across reload

# Body

## Summary

- register FFF-named tool definitions while the extension loads so restored `ffgrep` / `fffind` rows can resolve their renderers
- `session_start` still restores mode and enables the final tool names
- prune pre-registered names the final mode did not select: Pi activates tools on every `registerTool` call, so without this the early `ffgrep` / `fffind` registrations would stay visible to the model in override mode
- bind renderer titles to the registered name so historical `ffgrep` rows keep that name if the session later uses override mode

This is independent of #851. The renderer may be compact or non-compact; the bug is that historical rows lose any custom renderer after `/reload`.

## Scope

- historical override-mode `grep` / `find` rows are unchanged (builtin names always resolve)
- stale activations carried over from a previous mode across `/reload` (e.g. switching back from override) are a separate pre-existing hygiene issue, not handled here

## Verification

- `npm run typecheck`
- `npx --yes bun@1.3.8 test test/`

Both commands passed locally: 83 tests passed, 0 failed (includes a regression test for the override prune).

Manual TUI verification on a clean worktree: default-mode `ffgrep` history keeps its renderer after `/reload` and after quit/re-enter; fresh override session shows only `grep` / `find` active; `grep` / `find` calls work normally.

Fixes #853


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved original tool names in historical results after switching modes.
  - Improved saved-session restoration so previously recorded grep and find actions display their correct labels.
  - Removed outdated grep and find options from active tools when override mode is selected.
  - Improved startup handling so restored historical results render correctly before the current mode is restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->