### PR TITLE
fix(pi-fff): drop stale mode tool names on reload (#855)

### DIFF
--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -78,6 +78,10 @@ function resolveToolNames(mode: FffMode): ToolNames {
   return mode === "override" ? OVERRIDE_TOOL_NAMES : FFF_TOOL_NAMES;
 }
 
+function toolNameList(names: ToolNames): string[] {
+  return [names.grep, names.find, names.multiGrep];
+}
+
 // ---------------------------------------------------------------------------
 // Cursor store — simple bounded Map for pagination cursors
 // ---------------------------------------------------------------------------
@@ -656,11 +660,19 @@ export default function fffExtension(pi: ExtensionAPI) {
     });
   }
 
-  function registerPendingTools(): void {
+  // Pi carries the active tool list across /reload, so names activated under a
+  // previously used mode stay active unless we drop them here (#855).
+  function registerPendingTools(staleNames: readonly string[]): void {
     if (toolsRegistered) return;
 
-    const registeredNames = pendingTools.map((register) => register());
-    pi.setActiveTools([...new Set([...pi.getActiveTools(), ...registeredNames])]);
+    const registeredNames = new Set(pendingTools.map((register) => register()));
+    const stale = new Set(staleNames.filter((name) => !registeredNames.has(name)));
+    pi.setActiveTools([
+      ...new Set([
+        ...pi.getActiveTools().filter((name) => !stale.has(name)),
+        ...registeredNames,
+      ]),
+    ]);
     toolsRegistered = true;
   }
 
@@ -720,28 +732,24 @@ export default function fffExtension(pi: ExtensionAPI) {
     // Pi populates extension flag values after loading extensions.
     resolveStartupConfig();
 
+    // FFF-named tools are ours alone, so they are always safe to drop. Override
+    // names collide with pi's builtins and are only stale once this session ran
+    // in override mode, which is the sole way we could have activated them.
+    const staleNames = toolNameList(FFF_TOOL_NAMES);
+    let usedOverride = currentMode === "override";
+
     // Restore persisted mode before registering tools so a saved override
     // can safely change their names after /reload or session resume.
-    const entries = ctx.sessionManager?.getEntries();
-    if (entries) {
-      const modeEntry = [...entries]
-        .reverse()
-        .find(
-          (e: { type: string; customType?: string }) =>
-            e.type === "custom" && e.customType === "fff-mode",
-        );
-      if (
-        modeEntry &&
-        typeof (modeEntry as any).data?.mode === "string" &&
-        VALID_MODES.includes((modeEntry as any).data.mode as FffMode)
-      ) {
-        const restored = (modeEntry as any).data.mode as FffMode;
-        if (restored !== currentMode) setMode(restored);
-      }
+    const modes = sessionModes(ctx.sessionManager?.getEntries());
+    if (modes.length > 0) {
+      const restored = modes[modes.length - 1];
+      if (restored !== currentMode) setMode(restored);
+      usedOverride = usedOverride || modes.includes("override");
     }
+    if (usedOverride) staleNames.push(...toolNameList(OVERRIDE_TOOL_NAMES));
 
     initializeFinderFactories();
-    registerPendingTools();
+    registerPendingTools(staleNames);
   }
 
   pi.on("session_start", async (_event, ctx) => {
@@ -1357,4 +1365,23 @@ export default function fffExtension(pi: ExtensionAPI) {
       ctx.ui.notify("FFF rescan triggered", "info");
     },
   });
+}
+
+// Every mode this session selected via /fff-mode, oldest first.
+function sessionModes(entries: unknown): FffMode[] {
+  if (!Array.isArray(entries)) return [];
+
+  const modes: FffMode[] = [];
+  for (const entry of entries as {
+    type?: string;
+    customType?: string;
+    data?: unknown;
+  }[]) {
+    if (entry?.type !== "custom" || entry.customType !== "fff-mode") continue;
+    const mode = (entry.data as { mode?: unknown } | undefined)?.mode;
+    if (typeof mode === "string" && VALID_MODES.includes(mode as FffMode)) {
+      modes.push(mode as FffMode);
+    }
+  }
+  return modes;
 }

--- a/packages/pi-fff/test/extension.test.ts
+++ b/packages/pi-fff/test/extension.test.ts
@@ -147,7 +147,7 @@ function createPi(mode?: string, flags: Record<string, unknown> = {}) {
     registerTool: mock((_tool: any) => undefined),
     getActiveTools: mock(() => ["read"] as string[]),
     setActiveTools: mock((_names: string[]) => undefined),
-    appendEntry: mock(() => undefined),
+    appendEntry: mock((_customType: string, _data: unknown) => undefined),
   };
 
   return { pi, events, commands };
@@ -396,6 +396,83 @@ describe("pi-fff session mode", () => {
       "Current mode: 'tools-and-ui' (flag: unset)",
       "info",
     );
+    await shutdown(setup);
+  });
+});
+
+// Regression for #855: pi carries the active tool list and the session entries across
+// /reload, but drops the extension instance, so a mode switch must not leave the
+// previous mode's tool names active.
+describe("pi-fff mode switch across /reload", () => {
+  // Pi's own default active set: builtin grep/find ship inactive (dist/core/sdk.js).
+  const PI_DEFAULT_ACTIVE = ["read", "bash", "edit", "write"];
+
+  function createReloadableSession(startupMode?: string, active = PI_DEFAULT_ACTIVE) {
+    let activeTools = [...active];
+    const entries: unknown[] = [];
+
+    async function load() {
+      const setup = createPi(startupMode);
+      setup.pi.getActiveTools.mockImplementation(() => [...activeTools]);
+      setup.pi.setActiveTools.mockImplementation((names: string[]) => {
+        activeTools = [...names];
+      });
+      setup.pi.appendEntry.mockImplementation((customType: string, data: unknown) => {
+        entries.push({ type: "custom", customType, data });
+      });
+
+      const ctx = createContext();
+      ctx.sessionManager.getEntries.mockReturnValue(entries as any[]);
+      fffExtension(setup.pi as any);
+      await setup.events.get("session_start")?.({ reason: "startup" }, ctx);
+      return { ...setup, ctx };
+    }
+
+    return { load, getActiveTools: () => activeTools };
+  }
+
+  test("drops override tool names when switching back to a FFF-named mode", async () => {
+    const session = createReloadableSession("override");
+
+    const first = await session.load();
+    expect(session.getActiveTools()).toEqual([...PI_DEFAULT_ACTIVE, "grep", "find"]);
+    await first.commands.get("fff-mode").handler("tools-and-ui", first.ctx);
+    await shutdown(first);
+
+    const second = await session.load();
+    expect(session.getActiveTools()).toEqual([...PI_DEFAULT_ACTIVE, "ffgrep", "fffind"]);
+    await shutdown(second);
+  });
+
+  test("drops FFF tool names when switching to override", async () => {
+    const session = createReloadableSession("tools-and-ui");
+
+    const first = await session.load();
+    expect(session.getActiveTools()).toEqual([...PI_DEFAULT_ACTIVE, "ffgrep", "fffind"]);
+    await first.commands.get("fff-mode").handler("override", first.ctx);
+    await shutdown(first);
+
+    const second = await session.load();
+    expect(session.getActiveTools()).toEqual([...PI_DEFAULT_ACTIVE, "grep", "find"]);
+    await shutdown(second);
+  });
+
+  test("keeps user-enabled builtin grep and find when override was never used", async () => {
+    const session = createReloadableSession("tools-and-ui", [
+      ...PI_DEFAULT_ACTIVE,
+      "grep",
+      "find",
+    ]);
+
+    const setup = await session.load();
+
+    expect(session.getActiveTools()).toEqual([
+      ...PI_DEFAULT_ACTIVE,
+      "grep",
+      "find",
+      "ffgrep",
+      "fffind",
+    ]);
     await shutdown(setup);
   });
 });


### PR DESCRIPTION
Closes #855

## Root cause

`registerPendingTools` was purely additive (`packages/pi-fff/src/index.ts:659-665`), while pi hands the pre-reload active list straight back to the rebuilt tool registry (`dist/core/agent-session.js:2063`: `activeToolNames: this.getActiveToolNames()`). A `/reload` after a mode switch therefore keeps the previous mode's names active, and both directions are affected on `main`.

Relevant detail: pi's default active set is `["read", "bash", "edit", "write"]` (`dist/core/sdk.js:132`) — builtin `grep`/`find` are registered but inactive. A leftover `grep`/`find` in a FFF-named mode is genuinely the extension's stale activation.

## Fix

`registerPendingTools` now takes the names the final mode did not register and drops them from the active set. FFF names (`ffgrep`/`fffind`/`fff-multi-grep`) are pruned unconditionally — no one else registers them. Override names (`grep`/`find`/`multi_grep`) are pruned only when this session actually ran in override mode, determined from the startup-resolved mode plus every persisted `/fff-mode` entry, so a builtin `grep`/`find` the user enabled via `defaultTools` survives.

## Steps to reproduce

```sh
cd packages && bun install --frozen-lockfile
git checkout triage-bot/issue-855 -- pi-fff/test/extension.test.ts
cd pi-fff && bun test test/extension.test.ts
```

On pre-fix `main`:

```
(fail) pi-fff mode switch across /reload > drops override tool names when switching back to a FFF-named mode
(fail) pi-fff mode switch across /reload > drops FFF tool names when switching to override
 26 pass
 2 fail
```

Expected active tools after override -> `tools-and-ui` + `/reload`: `["read","bash","edit","write","ffgrep","fffind"]`.
Actual on `main`: `["read","bash","edit","write","grep","find","ffgrep","fffind"]` — four search tools, duplicated in pairs.

Manual equivalent (TUI):

```
pi -e packages/pi-fff/src/index.ts --fff-mode=override
/fff-mode tools-and-ui
/reload
/tool          # main: grep, find, ffgrep, fffind active. fixed: ffgrep, fffind
```

## How verified

```sh
cd packages/pi-fff && bun test test/     # 85 pass, 0 fail
cd packages && bun run format:check      # all matched files use the correct format
cd packages && bun run lint              # oxlint clean
cd packages/pi-fff && bun run typecheck  # no new errors
```

Three tests added modelling pi's real cross-reload behaviour (active list and session entries survive, extension instance does not): both switch directions, plus a guard that a user-enabled builtin `grep`/`find` is not pruned when override was never used. `typecheck` still reports the two pre-existing `TS7006` in `src/index.ts` and the unbuilt `@ff-labs/fff-node` resolution errors — identical on `main`.

@dmtrKovalenko one judgment call worth your eyes: telling the extension's `grep`/`find` from pi's builtins is impossible by name, so the prune leans on mode history as the evidence. If you would rather have hard provenance, the alternative is persisting the activated names in a session entry.

Overlaps #854, which touches the same function — the prune there becomes redundant with this one.

Automated triage via Gustav. Honk-Honk 🪿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `/reload` mode switches so tools from a previous mode no longer remain active.
  - Preserved user-enabled built-in tools, including `grep` and `find`, when reloading sessions or opting out of home-directory scanning.
  - Improved restoration of persisted session modes to keep the active tool list accurate.
  - Added clearer warnings when scanning is unavailable because a directory has opted out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->