### PR TITLE
fix(nvim): keep End path shortening on a char boundary

### DIFF
--- a/crates/fff-nvim/src/path_shortening.rs
+++ b/crates/fff-nvim/src/path_shortening.rs
@@ -184,10 +184,7 @@ impl PathShortenStrategy {
                 // If even the first component is too long, truncate it
                 if result.is_empty() && !components.is_empty() {
                     return components.first().map_or(String::new(), |component| {
-                        let mut component = component.to_string();
-
-                        component.truncate(max_size);
-                        component
+                        Self::truncate_str(component, max_size)
                     });
                 }
 
@@ -577,6 +574,22 @@ mod tests {
             shortened.len() <= 15,
             "Result '{}' should be <= 15 chars",
             shortened
+        );
+    }
+
+    #[test]
+    fn end_strategy_truncates_multibyte_first_component_on_char_boundary() {
+        // "документы" is 9 chars / 18 bytes, so a byte truncation at 15 lands
+        // inside a character.
+        let path = Path::new("документы/файл.txt");
+        let shortened = PathShortenStrategy::End.shorten_path(path, 15);
+        assert_eq!(shortened, "документы");
+
+        // ASCII is unchanged: still cut to exactly max_size.
+        let ascii = Path::new("core_workflow_service/db/model");
+        assert_eq!(
+            PathShortenStrategy::End.shorten_path(ascii, 15),
+            "core_workflow_s"
         );
     }
 


### PR DESCRIPTION
## The crash

With `layout.path_shorten_strategy = 'end'`, rendering a result whose directory
column has to be cut inside its first path component panics the Rust module when
that component is not ASCII:

```
thread 'path_shortening::tests::end_strategy_truncates_multibyte_first_component_on_char_boundary' (38540) panicked at crates\fff-nvim\src\path_shortening.rs:189:35:
assertion failed: self.is_char_boundary(new_len)
```

`shorten_path` reaches it whenever `components[0].len() > max_size` — the picker
window is narrow, or the filename is long, since `path_max_width` in
`renderer.lua` is `max_width - strdisplaywidth(filename) - 1`.

## Root cause

`PathShortenStrategy::End` is the one place in the file that cuts a component
with `String::truncate`, which takes a **byte** length and panics off a char
boundary:

```rust
let mut component = component.to_string();
component.truncate(max_size);
```

Every other cut in this module goes through `Self::truncate_str` /
`Self::truncate_str_keep_end`, which count **chars**. The single-component branch
a few lines up in the same function already calls `Self::truncate_str(components[0], max_size)`
for exactly this situation — the multi-component branch was missed.

Chars are also the right unit here: `max_size` arrives from
`lua/fff/picker_ui/renderer.lua` as a `strdisplaywidth`-derived column budget,
not a byte count.

## The fix

Use the existing helper, matching the sibling branch.

## Verification (Windows, default `ripgrep` features)

`RUSTUP_TOOLCHAIN` was pinned to `1.98.0-x86_64-pc-windows-msvc` because
`rust-toolchain.toml`'s `stable` channel could not update on this machine.

New test `end_strategy_truncates_multibyte_first_component_on_char_boundary`
feeds `документы/файл.txt` (9 chars / 18 bytes in the first component) with
`max_size = 15`, which lands inside a character.

Before, `cargo test -p fff-nvim --lib -- path_shortening`:

```
running 9 tests

thread 'path_shortening::tests::end_strategy_truncates_multibyte_first_component_on_char_boundary' (38540) panicked at crates\fff-nvim\src\path_shortening.rs:189:35:
assertion failed: self.is_char_boundary(new_len)

test result: FAILED. 8 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

After:

```
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The same test pins the ASCII behaviour that must not change —
`core_workflow_service/db/model` at `max_size = 15` still yields exactly
`core_workflow_s` — and it passes both before and after, as does the existing
`test_path_shroten_strategy_end`. For ASCII the two helpers are identical, so
nothing widens.

- `cargo test -p fff-nvim --lib` — 9 passed, 0 failed.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p fff-nvim --lib` — no new warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved path shortening for long paths containing multibyte UTF-8 characters.
  - Prevented characters from being split incorrectly during truncation.
  - Preserved existing behavior for ASCII-only paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->