### PR TITLE
chore: regenerate Neovim vimdoc

### DIFF
--- a/doc/fff.nvim.txt
+++ b/doc/fff.nvim.txt
@@ -1,5 +1,5 @@
 *fff.nvim.txt*
-                           For Neovim >= 0.10.0    Last change: 2026 August 25
+                        For Neovim >= 0.10.0    Last change: 2026 September 10
 
 ==============================================================================
 Table of Contents                                 *fff.nvim-table-of-contents*
@@ -138,6 +138,7 @@ Each match item has `relative_path`, `name`, `line_number`, `col`,
       page_size             = 50,
       file_offset           = 0,
       time_budget_ms        = 0,
+      enforce_time_budget   = false,    -- also bound zero-match searches
       trim_whitespace       = false,
       cwd                   = nil,      -- switch indexed root if different
       wait_for_index_ms     = nil,      -- override the default scan wait timeout
@@ -300,6 +301,7 @@ Defaults are sensible. Override only what you care about.
         max_matches_per_file = 100,
         smart_case = true,
         time_budget_ms = 150,
+        enforce_time_budget = false, -- apply time_budget_ms even before anything matched (off = zero-match queries scan everything)
         modes = { 'plain', 'regex', 'fuzzy' },
         trim_whitespace = false,
         enable_filename_constraint = false, -- treat filename-like tokens (e.g. `score.rs`) in a grep query as a file-path filter scoping the search; off = searched as literal text


### PR DESCRIPTION
Automated vimdoc regeneration from README.md, scribed by Gustav.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the `enforce_time_budget` option for content and grep searches.
  * Clarified that enabling this option applies the configured time limit even when no matches have been found.
  * Updated the documentation’s “Last change” date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->