### PR TITLE
fix(core): compare relative paths longer than 512 bytes

### DIFF
--- a/crates/fff-core/src/simd_path.rs
+++ b/crates/fff-core/src/simd_path.rs
@@ -527,6 +527,29 @@ mod tests {
     }
 
     #[test]
+    fn test_relative_path_eq_path_exceeding_512_bytes() {
+        let mut path = String::new();
+        while path.len() < 600 {
+            path.push_str("deeply_nested_directory_segment/");
+        }
+        path.push_str("needle_file.rs");
+        assert!(path.len() > 512 && path.len() < PATH_BUF_SIZE);
+
+        let (store, _strings, files) = build_test_store(&[path.as_str(), "src/lib.rs"]);
+        let arena = store.as_arena_ptr();
+
+        assert!(
+            files[0].relative_path_eq(arena, &path),
+            "a PATH_MAX-legal path must compare equal to itself"
+        );
+
+        // Short paths keep comparing exactly as before.
+        assert!(files[1].relative_path_eq(arena, "src/lib.rs"));
+        assert!(!files[1].relative_path_eq(arena, "src/main.rs"));
+        assert!(!files[0].relative_path_eq(arena, &path[..path.len() - 1]));
+    }
+
+    #[test]
     fn test_filename_cow_mid_chunk() {
         let (store, strings, _files) = build_test_store(&["src/components/Button.tsx"]);
         let arena = store.as_arena_ptr();

--- a/crates/fff-core/src/types.rs
+++ b/crates/fff-core/src/types.rs
@@ -372,7 +372,7 @@ impl FileItem {
         if other.len() != self.path.byte_len as usize {
             return false;
         }
-        let mut buf = [0u8; 512];
+        let mut buf = [0u8; PATH_BUF_SIZE];
         let mine = self.path.read_to_buf(arena, &mut buf);
         mine == other
     }


### PR DESCRIPTION
## The defect

`FileItem::relative_path_eq` reads the stored path into a `[0u8; 512]` scratch
buffer. `ChunkedString::read_to_buf` documents that it "Truncates at `buf.len()`
if exceeded -- use `[u8; PATH_BUF_SIZE]` to avoid", so for any relative path
longer than 512 bytes the comparison sees a 512-byte prefix, the lengths no
longer match, and the function returns `false` **for a path compared against
itself**.

`relative_path_starts_with`, immediately below it in the same `impl`, already
uses `[0u8; PATH_BUF_SIZE]`. This is the one call site that kept the old size.

`test_resolve_ptrs_path_exceeding_512_bytes` (added with the `resolve_ptrs` fix)
makes the rule explicit for the same limit:

> Truncation is not acceptable either: it silently drops the tail of the path
> (including the filename here) from fuzzy matching.

## Why it matters

`relative_path_eq` has two callers:

- `FilePickerSyncData::find_file_index` — the linear scan over the overflow
  region, i.e. the lookup for every file the watcher appended after the initial
  scan. It backs `handle_create_or_modify`, `remove_file_by_path`,
  `get_file_by_path` and `update_single_file_frecency`. A watcher-added file
  whose relative path exceeds 512 bytes is never found, so a modify appends a
  second entry instead of updating the existing one, and a delete never
  tombstones it.
- `calculate_current_file_penalty` — the current buffer stops being penalised,
  so the file you are already in keeps ranking first.

`PATH_BUF_SIZE` is `PATH_MAX` (and 4096 on Windows), so these paths are legal
and reachable in deeply nested trees.

## The fix

Use `PATH_BUF_SIZE`, matching `relative_path_starts_with`. The length check
above it short-circuits before the buffer is created, so the larger array is
only built for a candidate that already has the right length.

## Verification (Windows, default `ripgrep` features)

`RUSTUP_TOOLCHAIN` was pinned to `1.98.0-x86_64-pc-windows-msvc` because
`rust-toolchain.toml`'s `stable` channel could not update on this machine.

New test `test_relative_path_eq_path_exceeding_512_bytes` reuses the >512-byte
path from the neighbouring `resolve_ptrs` regression test.

Before, `cargo test -p fff-search --lib -- simd_path`:

```
test simd_path::tests::test_relative_path_eq_path_exceeding_512_bytes ... FAILED

---- simd_path::tests::test_relative_path_eq_path_exceeding_512_bytes stdout ----

thread 'simd_path::tests::test_relative_path_eq_path_exceeding_512_bytes' (6108) panicked at crates\fff-core\src\simd_path.rs:541:9:
a PATH_MAX-legal path must compare equal to itself

test result: FAILED. 14 passed; 1 failed; 0 ignored; 0 measured; 145 filtered out
```

After:

```
test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 145 filtered out
```

The same test pins the short-path behaviour that must not change — `src/lib.rs`
still equals itself, still differs from `src/main.rs`, and the long path still
differs from a one-byte-shorter prefix of itself. Those three assertions pass
both before and after, so nothing is widened.

- `cargo test -p fff-search --lib` — 160 passed, 0 failed.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p fff-search --lib` — no new warnings (the three that fire
  under the default `ripgrep` features are in `path_utils.rs` and
  `file_picker.rs`, untouched here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file path comparisons for paths longer than 512 bytes.
  - Preserved accurate comparisons for shorter paths and correctly rejects truncated paths.

- **Tests**
  - Added coverage for long relative paths to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->