### PR TITLE
fix(core): stop labelling unclassified git statuses as clean

### DIFF
--- a/crates/fff-core/src/git.rs
+++ b/crates/fff-core/src/git.rs
@@ -159,7 +159,9 @@ pub fn format_git_status_opt(status: Option<Status>) -> Option<&'static str> {
                 Some("staged_deleted")
             } else if status.contains(Status::IGNORED) {
                 Some("ignored")
-            } else if status.contains(Status::CURRENT) || status.is_empty() {
+            // `Status::CURRENT` is 0, so `contains` is true for every status:
+            // testing it here labelled conflicted/typechanged files "clean".
+            } else if status.is_empty() {
                 Some("clean")
             } else {
                 None
@@ -190,6 +192,35 @@ mod tests {
             .output()
             .unwrap();
         assert!(out.status.success(), "git {args:?} failed");
+    }
+
+    #[test]
+    fn unclassified_status_is_not_reported_as_clean() {
+        // A merge-conflicted file must not claim to be clean.
+        assert_eq!(format_git_status_opt(Some(Status::CONFLICTED)), None);
+        assert_eq!(format_git_status(Some(Status::CONFLICTED)), "unknown");
+        assert_eq!(format_git_status(Some(Status::WT_TYPECHANGE)), "unknown");
+
+        // Every already-classified state keeps its label.
+        assert_eq!(format_git_status_opt(None), Some("clean"));
+        assert_eq!(format_git_status_opt(Some(Status::empty())), Some("clean"));
+        assert_eq!(format_git_status_opt(Some(Status::CURRENT)), Some("clean"));
+        assert_eq!(
+            format_git_status_opt(Some(Status::WT_NEW)),
+            Some("untracked")
+        );
+        assert_eq!(
+            format_git_status_opt(Some(Status::WT_MODIFIED)),
+            Some("modified")
+        );
+        assert_eq!(
+            format_git_status_opt(Some(Status::INDEX_MODIFIED)),
+            Some("staged_modified")
+        );
+        assert_eq!(
+            format_git_status_opt(Some(Status::IGNORED)),
+            Some("ignored")
+        );
     }
 
     /// Regression: on case-insensitive filesystems libgit2 returns


### PR DESCRIPTION
## The defect

A merge-conflicted file is reported as `clean`.

`format_git_status_opt` ends with:

```rust
} else if status.contains(Status::CURRENT) || status.is_empty() {
    Some("clean")
} else {
    None
}
```

`GIT_STATUS_CURRENT` is `0` in libgit2, so `git2::Status::CURRENT` is the empty
bitflag and `status.contains(Status::CURRENT)` is vacuously true for **every**
status. Every state the chain does not name explicitly therefore falls out as
`clean`, and the `else { None }` arm — plus `format_git_status`'s
`unwrap_or("unknown")` — is unreachable.

The states that hit it: `CONFLICTED`, `WT_TYPECHANGE`, `INDEX_TYPECHANGE`,
`INDEX_RENAMED`.

`CONFLICTED` genuinely reaches this function: `fuzz_git_watcher_stress.rs`
already asserts "picker must surface CONFLICTED after merge". So after a
conflicted merge the picker shows those files as clean, and since #845 the MCP
output drops the annotation entirely rather than flagging anything.

The Lua layer is already set up for the fallback — `GIT_LABELS` in
`lua/fff/file_picker/file_info.lua` carries `unknown = '?'`, a label the Rust
side could never produce.

## The fix

Test `is_empty()` and let anything else fall through to the existing `unknown`
fallback, as the code was written to do.

## Verification (Windows, default `ripgrep` features)

`RUSTUP_TOOLCHAIN` was pinned to `1.98.0-x86_64-pc-windows-msvc` because
`rust-toolchain.toml`'s `stable` channel could not update on this machine.

Before, `cargo test -p fff-search --lib -- git::`:

```
test git::tests::unclassified_status_is_not_reported_as_clean ... FAILED

---- git::tests::unclassified_status_is_not_reported_as_clean stdout ----

thread 'git::tests::unclassified_status_is_not_reported_as_clean' (41116) panicked at crates\fff-core\src\git.rs:198:9:
assertion `left == right` failed
  left: Some("clean")
 right: None

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 158 filtered out
```

After:

```
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 158 filtered out
```

The same test pins every label that must not move — `None`, `Status::empty()`
and `Status::CURRENT` all still read `clean`, and `untracked` / `modified` /
`staged_modified` / `ignored` are unchanged. Those assertions pass both before
and after, so only the previously-misfiled states move.

- `cargo test -p fff-search --lib` — 160 passed, 0 failed.
- `cargo test -p fff-mcp --bins` — 22 passed, 0 failed (covers
  `suffix_omits_clean_git_status` and `suffix_keeps_dirty_git_status`).
- `cargo fmt --all -- --check` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Git status reporting now correctly identifies conflicted and type-changed files instead of incorrectly labeling them as clean.
  - Existing recognized Git status labels remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->