### PR TITLE
fix(query-parser): parse file:line after a Windows drive letter

### DIFF
--- a/crates/fff-query-parser/src/location.rs
+++ b/crates/fff-query-parser/src/location.rs
@@ -118,18 +118,26 @@ fn try_parse_column_position(location: &str) -> Option<Location> {
 
 /// Parses various location formats like file:12, file:12:4, file:12-114
 fn parse_column_location(query: &str) -> Option<(&str, Location)> {
-    let (file_path, location_part) = query.split_once(':')?;
+    // Left to right, because `file:12:4` splits at its first colon. A Windows
+    // drive letter (`C:\...`) just makes that first colon fail and we move on.
+    let mut from = 0;
+    while let Some(offset) = query[from..].find(':') {
+        let at = from + offset;
+        let location_part = &query[at + 1..];
 
-    if let Some(range_location) = try_parse_column_range(location_part) {
-        return Some((file_path, range_location));
-    }
+        if let Some(range_location) = try_parse_column_range(location_part) {
+            return Some((&query[..at], range_location));
+        }
 
-    if let Some(position_location) = try_parse_column_position(location_part) {
-        return Some((file_path, position_location));
-    }
+        if let Some(position_location) = try_parse_column_position(location_part) {
+            return Some((&query[..at], position_location));
+        }
 
-    if let Ok(line_location) = location_part.parse::<i32>() {
-        return Some((file_path, Location::Line(line_location)));
+        if let Ok(line_location) = location_part.parse::<i32>() {
+            return Some((&query[..at], Location::Line(line_location)));
+        }
+
+        from = at + 1;
     }
 
     None
@@ -261,5 +269,27 @@ mod tests {
         );
         assert_eq!(parse_location("file:-"), ("file", None));
         assert_eq!(parse_location("file("), ("file", None));
+    }
+
+    #[test]
+    fn parses_location_after_a_windows_drive_letter() {
+        assert_eq!(
+            parse_location(r"C:\Users\me\file.rs:12"),
+            (r"C:\Users\me\file.rs", Some(Location::Line(12)))
+        );
+        assert_eq!(
+            parse_location(r"C:\src\main.rs:12:4"),
+            (
+                r"C:\src\main.rs",
+                Some(Location::Position { line: 12, col: 4 })
+            )
+        );
+
+        // A colon that starts no location still leaves the query untouched.
+        assert_eq!(
+            parse_location(r"C:\Users\me\file.rs"),
+            (r"C:\Users\me\file.rs", None)
+        );
+        assert_eq!(parse_location("foo:bar"), ("foo:bar", None));
     }
 }


### PR DESCRIPTION
## The defect

`parse_location` drops the location suffix of any Windows absolute path:

```
parse_location(r"C:\Users\me\file.rs:12")
  -> ("C:\\Users\\me\\file.rs:12", None)   // expected ("C:\\Users\\me\\file.rs", Line(12))
```

`parse_column_location` splits on the **first** colon and gives up if that one
split does not yield a location:

```rust
let (file_path, location_part) = query.split_once(':')?;
```

On `C:\Users\me\file.rs:12` the first colon is the drive separator, so
`location_part` is `\Users\me\file.rs:12`, none of the three shapes parse, and
the whole query falls through as plain text. Pasting a path from a compiler
error, a stack trace or grep output into the picker opens the file at line 1
instead of the line named in it — or, since the query still carries the `:12`,
finds nothing.

Unix absolute paths are unaffected (`/Users/.../file.rs:12` has no earlier
colon), which is why the single-token guard in `parser.rs` that was written for
exactly this shape — "the token looks like an absolute file path with a location
suffix (e.g. `/Users/.../file.rs:12`)" — never surfaced it.

## The fix

Keep scanning colons left to right instead of giving up after the first one.
Left to right is load-bearing: `file:12:4` must still split at its first colon
so the location part is `12:4`, not `4`.

## Verification (Windows, default features)

`RUSTUP_TOOLCHAIN` was pinned to `1.98.0-x86_64-pc-windows-msvc` because
`rust-toolchain.toml`'s `stable` channel could not update on this machine.

Before, `cargo test -p fff-query-parser --lib -- location`:

```
test location::tests::parses_location_after_a_windows_drive_letter ... FAILED

---- location::tests::parses_location_after_a_windows_drive_letter stdout ----

thread 'location::tests::parses_location_after_a_windows_drive_letter' (35060) panicked at crates\fff-query-parser\src\location.rs:268:9:
assertion `left == right` failed
  left: ("C:\\Users\\me\\file.rs:12", None)
 right: ("C:\\Users\\me\\file.rs", Some(Line(12)))

test result: FAILED. 6 passed; 1 failed; 0 ignored; 0 measured; 82 filtered out
```

After:

```
test result: ok. 89 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Pins that the scan does not widen anything, all passing before and after:

- `C:\Users\me\file.rs` (colon, no location) stays untouched, as does `foo:bar`
  — the new assertions in the same test.
- `test_location_parsing` keeps `file:12:4` at `Position { 12, 4 }` (not
  `Line(4)`), `file:12ab` at `None`, and the four range shapes unchanged.
- `test_grep_no_location_parsing_single_token`, `test_grep_no_location_parsing_multi_token`
  and `test_absolute_path_with_location_not_path_segment` are unchanged.

- `cargo test -p fff-query-parser` — 89 lib + 3 doc tests passed, 0 failed.
- `cargo test -p fff-search --lib` — 159 passed, 0 failed.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p fff-query-parser --lib` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved location parsing for Windows drive-letter paths such as `C:\...`.
  - Queries with multiple colons are now handled correctly by identifying the first valid location marker.
  - Queries containing colons that do not begin a valid location continue to return no location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->