### PR TITLE
fix(core): skip only the binary file, not the rest of its bigram chunk

### DIFF
--- a/crates/fff-core/src/index/bigram_filter.rs
+++ b/crates/fff-core/src/index/bigram_filter.rs
@@ -855,7 +855,7 @@ pub(crate) fn build_bigram_index(
                     let file_idx = base_idx + offset;
 
                     if file.is_binary() || file.size == 0 {
-                        return;
+                        continue;
                     }
 
                     READ_BUF.with(|read_cell| {
@@ -1224,5 +1224,54 @@ mod tests {
         // cd in word 1, bit 0
         assert_eq!(cd_bitset[0], 0);
         assert_eq!(cd_bitset[1], 1);
+    }
+
+    /// `build_bigram_index` skips binary and empty files. A skipped file must
+    /// not take the rest of its `BIGRAM_CHUNK_FILES` chunk down with it.
+    #[test]
+    fn a_skipped_file_does_not_drop_the_rest_of_its_chunk() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let base = tmp.path();
+
+        // Index 0 is empty, so the guard fires on the very first file of the
+        // chunk; the nine text files behind it must still be indexed.
+        let mut names: Vec<String> = vec!["a_empty.txt".to_string()];
+        std::fs::write(base.join("a_empty.txt"), "").unwrap();
+        for i in 0..9 {
+            let name = format!("f{i}.txt");
+            let body = if i < 2 {
+                "the unicorn line\n"
+            } else {
+                "plain filler content\n"
+            };
+            std::fs::write(base.join(&name), body).unwrap();
+            names.push(name);
+        }
+
+        let mut files: Vec<FileItem> = names
+            .iter()
+            .map(|name| {
+                let size = std::fs::metadata(base.join(name)).unwrap().len();
+                FileItem::new_raw(0, size, 0, None, false)
+            })
+            .collect();
+        let (store, strings) =
+            crate::simd_path::build_chunked_path_store_from_strings(&names, &files);
+        for (file, path) in files.iter_mut().zip(strings) {
+            file.set_path(path);
+        }
+
+        let index = build_bigram_index(&files, base, store.as_arena_ptr());
+        let candidates = index
+            .query(b"unicorn")
+            .expect("the text files must be in the index");
+
+        assert!(
+            BigramFilter::is_candidate(&candidates, 1),
+            "f0.txt is behind the skipped file and must still be a candidate"
+        );
+        assert!(BigramFilter::is_candidate(&candidates, 2));
+        // Files without the needle stay filtered out.
+        assert!(!BigramFilter::is_candidate(&candidates, 5));
     }
 }


### PR DESCRIPTION
## The defect

`build_bigram_index` walks each `BIGRAM_CHUNK_FILES` (256) chunk in a
`for_each` closure, and the per-file skip is a `return`:

```rust
.for_each(|(chunk_idx, chunk)| {
    let base_idx = chunk_idx * BIGRAM_CHUNK_FILES;
    for (offset, file) in chunk.iter().enumerate() {
        let file_idx = base_idx + offset;

        if file.is_binary() || file.size == 0 {
            return;              // leaves the closure, not the iteration
        }
```

`return` exits the whole closure, so the first binary or zero-byte file in a
chunk takes **every file behind it in that chunk** out of the content index —
up to 255 of them. The guard is written per file (it re-reads `file` each
iteration and computes `file_idx` for it), so `continue` is what it means.

Those files then carry no bits in any bigram column. `prefilter_files` walks
the candidate bitset, so while a bigram prefilter is active they are never
selected: plain grep reports no match in them, silently, until the next full
rescan rebuilds the index.

## Reachability

`run_post_scan` passes `files[..indexable_count]`, and `collect_files`
partitions binary/empty/oversized files out of that prefix — so on a quiet tree
the guard does not fire. The prefix is not stable, though: `run_post_scan`
reads a `PostScanUnsafeSnapshot` that the watcher mutates while the index is
being built, which its own doc comment spells out ("it can only WRITE
information using single instructions").

The watcher writes both fields the guard reads. `handle_file_modify` calls
`file.update_metadata(.., Some(size))`, which assigns `self.size = size`
unconditionally — including the `0` an editor leaves behind when it truncates
before writing — and re-runs `detect_binary_per_byte`, which can flip
`is_binary` on a file that is already inside the indexable prefix.

On a rescan the watcher is live throughout: `rescubscribe_watcher_post_scan`
runs immediately before `run_post_scan` in the same function. So one save
landing during a rescan can cost a 256-file chunk its content index.

The reproduction below drives the closure behaviour directly; the watcher race
itself is not reproduced here.

## Verification (Windows, default `ripgrep` features)

`RUSTUP_TOOLCHAIN` was pinned to `1.98.0-x86_64-pc-windows-msvc` because
`rust-toolchain.toml`'s `stable` channel could not update on this machine.

New test `a_skipped_file_does_not_drop_the_rest_of_its_chunk` builds an index
over ten files where index 0 is empty and two of the nine behind it contain a
needle.

Before, `cargo test -p fff-search --lib -- a_skipped_file`:

```
test index::bigram_filter::tests::a_skipped_file_does_not_drop_the_rest_of_its_chunk ... FAILED

---- index::bigram_filter::tests::a_skipped_file_does_not_drop_the_rest_of_its_chunk stdout ----

thread '...' (40876) panicked at crates\fff-core\src\index\bigram_filter.rs:1267:14:
the text files must be in the index

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 159 filtered out
```

`index.query` returns `None` because nothing at all was indexed: the empty file
at index 0 ended the chunk before any of the nine were read.

After:

```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 159 filtered out
```

The same test pins that filtering still filters — file 5 has no needle and must
not be a candidate — which holds after the fix and is what makes this a fix and
not a widening.

- `cargo test -p fff-search --lib` — 160 passed, 0 failed.
- `cargo test -p fff-search --test bigram_overlay_integration --test bigram_overlay_coherence_test --test dir_index_consistency_test` — 4, 7 and 17 passed, 0 failed.
- `cargo test -p fff-search --test grep_integration` — 68 passed. Note
  `large_binary_with_nuls_past_header_is_classified` is flaky on this machine
  independently of this change: 1 failure in 11 runs on unmodified `main`,
  2 in 15 with the patch. Its readiness gate is `bigram_index().is_some()`,
  which `run_post_scan` satisfies before `sniff_binary_for_non_indexable` has
  classified the file it asserts on. That file is >2 MiB, so it is in the
  non-indexable region and never reaches the loop this PR touches.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p fff-search --lib --tests` — no new warnings.
