### PR TITLE
Fix pi-fff worktree path constraints

### DIFF
--- a/packages/pi-fff/pi-fff.schema.json
+++ b/packages/pi-fff/pi-fff.schema.json
@@ -46,6 +46,12 @@
       "type": "boolean",
       "default": true,
       "description": "Indexes through directory symlinks, e.g. a git worktree or stow layout whose files live behind links. Set to false to keep the walk inside the real tree."
+    },
+    "defaultExcludes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "default": [],
+      "description": "Path constraints to exclude from every find and grep query unless the query path explicitly targets one of them."
     }
   }
 }

--- a/packages/pi-fff/src/config.ts
+++ b/packages/pi-fff/src/config.ts
@@ -16,6 +16,7 @@ export interface FffConfig {
   enableHomeDirScanning?: boolean;
   warnOnHomeDirScan?: boolean;
   followSymlinks?: boolean;
+  defaultExcludes?: string[];
 }
 
 const CONFIG_KEYS = new Set<keyof FffConfig>([
@@ -27,6 +28,7 @@ const CONFIG_KEYS = new Set<keyof FffConfig>([
   "enableHomeDirScanning",
   "warnOnHomeDirScan",
   "followSymlinks",
+  "defaultExcludes",
 ]);
 
 export function loadConfig(agentDir = piDataDir()): FffConfig {
@@ -70,6 +72,7 @@ export function loadConfig(agentDir = piDataDir()): FffConfig {
   validateBoolean(configPath, parsed, "enableHomeDirScanning");
   validateBoolean(configPath, parsed, "warnOnHomeDirScan");
   validateBoolean(configPath, parsed, "followSymlinks");
+  validateStringArray(configPath, parsed, "defaultExcludes");
 
   return parsed as FffConfig;
 }
@@ -109,5 +112,20 @@ function validateBoolean(
   const value = config[key];
   if (value !== undefined && typeof value !== "boolean") {
     throw invalidConfig(configPath, `"${key}" must be a boolean`);
+  }
+}
+
+function validateStringArray(
+  configPath: string,
+  config: Record<string, unknown>,
+  key: "defaultExcludes",
+): void {
+  const value = config[key];
+  if (value === undefined) return;
+  if (
+    !Array.isArray(value) ||
+    value.some((item) => typeof item !== "string" || item.length === 0)
+  ) {
+    throw invalidConfig(configPath, `"${key}" must be an array of non-empty strings`);
   }
 }

--- a/packages/pi-fff/src/index.ts
+++ b/packages/pi-fff/src/index.ts
@@ -350,6 +350,7 @@ export default function fffExtension(pi: ExtensionAPI) {
   let enableHomeDirScanning = true;
   let warnOnHomeDirScan = true;
   let followSymlinks = true;
+  let defaultExcludes: string[] = [];
 
   function setMode(mode: FffMode): void {
     currentMode = mode;
@@ -408,6 +409,7 @@ export default function fffExtension(pi: ExtensionAPI) {
       true,
       parseBoolean,
     );
+    defaultExcludes = config.defaultExcludes ?? [];
   }
 
   function getMode(): FffMode {
@@ -550,7 +552,13 @@ export default function fffExtension(pi: ExtensionAPI) {
     // constraint stays relative to the picker's actual root.
     const rebase = nodePath.relative(aux.root, route.root).replaceAll(nodePath.sep, "/");
     const suffix = [rebase, route.suffix].filter(Boolean).join("/");
-    const query = buildQuery(suffix || undefined, pattern, exclude, aux.root);
+    const query = buildQuery(
+      suffix || undefined,
+      pattern,
+      exclude,
+      aux.root,
+      defaultExcludes,
+    );
     return { finder: aux.finder, query, root: aux.root };
   }
 
@@ -878,7 +886,7 @@ export default function fffExtension(pi: ExtensionAPI) {
       const context = clampContext(params.context);
       const query = aux
         ? aux.query
-        : buildQuery(params.path, pattern, params.exclude, activeCwd);
+        : buildQuery(params.path, pattern, params.exclude, activeCwd, defaultExcludes);
 
       // Auto-detect: regex if the pattern has regex metacharacters AND parses
       // as a valid regex, otherwise plain literal. The fuzzy fallback below
@@ -1080,7 +1088,13 @@ export default function fffExtension(pi: ExtensionAPI) {
         ? resumed.query
         : aux && "query" in aux
           ? (aux as { query: string }).query
-          : buildQuery(params.path, params.pattern, params.exclude, activeCwd);
+          : buildQuery(
+              params.path,
+              params.pattern,
+              params.exclude,
+              activeCwd,
+              defaultExcludes,
+            );
 
       const pattern = resumed ? resumed.pattern : params.pattern;
       const pageIndex = resumed?.nextPageIndex ?? 0;

--- a/packages/pi-fff/src/query.ts
+++ b/packages/pi-fff/src/query.ts
@@ -25,17 +25,6 @@ export function normalizePathConstraint(
   // wif we left with the ** it means anything so treat it as a cwd path
   if (trimmed === "**" || trimmed === "**/" || trimmed === "**/*") return null;
 
-  // FFF's glob matcher can treat a hidden directory root glob such as
-  // `.agents/**` as empty, while the tool contract says this means "inside
-  // this directory". Collapse simple trailing recursive directory globs to the
-  // directory-prefix constraint understood by the parser. Keep real file globs
-  // such as `src/**/*.ts` unchanged.
-  const recursiveDir = trimmed.match(/^(.*)\/\*\*(?:\/\*)?$/);
-  if (recursiveDir) {
-    const dir = recursiveDir[1];
-    if (dir && !/[*?[{]/.test(dir)) return `${dir}/`;
-  }
-
   // Already signals path-constraint syntax to the parser.
   if (trimmed.startsWith("/") || trimmed.endsWith("/")) return trimmed;
   // Globs (`*.ts`, `src/**/*.cc`, `{src,lib}`) are handled by the parser.
@@ -73,18 +62,36 @@ export function normalizeExcludes(
   return out;
 }
 
+function pathTargetsExcludedRoot(
+  pathConstraint: string | undefined,
+  excludes: string[],
+  cwd: string,
+): boolean {
+  if (!pathConstraint || excludes.length === 0) return false;
+  const normalized = normalizePathConstraint(pathConstraint, cwd);
+  if (!normalized) return false;
+  return excludes.some(
+    (exclude) => normalized === exclude || normalized.startsWith(exclude),
+  );
+}
+
 export function buildQuery(
   path: string | undefined,
   pattern: string,
   exclude?: string | string[],
   cwd = process.cwd(),
+  defaultExcludes: string[] = [],
 ): string {
   const parts: string[] = [];
   if (path) {
     const pathConstraint = normalizePathConstraint(path, cwd);
     if (pathConstraint) parts.push(pathConstraint);
   }
-  parts.push(...normalizeExcludes(exclude, cwd));
+  const activeDefaultExcludes = pathTargetsExcludedRoot(path, defaultExcludes, cwd)
+    ? []
+    : defaultExcludes;
+  const callerExcludes = exclude ? (Array.isArray(exclude) ? exclude : [exclude]) : [];
+  parts.push(...normalizeExcludes([...activeDefaultExcludes, ...callerExcludes], cwd));
   parts.push(pattern);
   return parts.join(" ");
 }

--- a/packages/pi-fff/test/config.test.ts
+++ b/packages/pi-fff/test/config.test.ts
@@ -33,6 +33,7 @@ describe("loadConfig", () => {
       enableHomeDirScanning: false,
       warnOnHomeDirScan: false,
       followSymlinks: true,
+      defaultExcludes: [".worktrees/", ".claude/worktrees/"],
     };
     writeConfig(config);
 
@@ -70,6 +71,14 @@ describe("loadConfig", () => {
       [{ enableHomeDirScanning: "false" }, '"enableHomeDirScanning" must be a boolean'],
       [{ warnOnHomeDirScan: "false" }, '"warnOnHomeDirScan" must be a boolean'],
       [{ followSymlinks: "true" }, '"followSymlinks" must be a boolean'],
+      [
+        { defaultExcludes: "test/" },
+        '"defaultExcludes" must be an array of non-empty strings',
+      ],
+      [
+        { defaultExcludes: ["test/", ""] },
+        '"defaultExcludes" must be an array of non-empty strings',
+      ],
     ];
 
     for (const [config, message] of cases) {

--- a/packages/pi-fff/test/query.test.ts
+++ b/packages/pi-fff/test/query.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { buildQuery, normalizePathConstraint } from "../src/query";
 
 const cwd = "/tmp/workspace";
+const defaultExcludes = [".worktrees/", ".claude/worktrees/"];
 
 describe("path constraint normalization", () => {
   test("converts absolute in-workspace paths to repo-relative constraints", () => {
-    expect(normalizePathConstraint("/tmp/workspace/.agents/**", cwd)).toBe(".agents/");
+    expect(normalizePathConstraint("/tmp/workspace/.agents/**", cwd)).toBe(".agents/**");
     expect(normalizePathConstraint("/tmp/workspace/.agents/plans/**", cwd)).toBe(
-      ".agents/plans/",
+      ".agents/plans/**",
     );
   });
 
@@ -17,9 +18,9 @@ describe("path constraint normalization", () => {
     );
   });
 
-  test("collapses only simple trailing recursive directory globs", () => {
-    expect(normalizePathConstraint(".agents/**", cwd)).toBe(".agents/");
-    expect(normalizePathConstraint("src/**/*", cwd)).toBe("src/");
+  test("preserves recursive directory globs as root-relative constraints", () => {
+    expect(normalizePathConstraint(".agents/**", cwd)).toBe(".agents/**");
+    expect(normalizePathConstraint("src/**/*", cwd)).toBe("src/**/*");
     expect(normalizePathConstraint("src/**/*.ts", cwd)).toBe("src/**/*.ts");
     expect(normalizePathConstraint("{src,lib}/**", cwd)).toBe("{src,lib}/**");
   });
@@ -27,7 +28,7 @@ describe("path constraint normalization", () => {
   test("builds find queries with normalized include and exclude constraints", () => {
     expect(
       buildQuery("/tmp/workspace/.agents/**", "*", "/tmp/workspace/test/**", cwd),
-    ).toBe(".agents/ !test/ *");
+    ).toBe(".agents/** !test/** *");
   });
 
   test("treats path='.' as workspace root (no constraint)", () => {
@@ -75,5 +76,28 @@ describe("path constraint normalization", () => {
     expect(normalizePathConstraint("**/*", cwd)).toBeNull();
     expect(normalizePathConstraint("./**", cwd)).toBeNull();
     expect(buildQuery("**", "needle", undefined, cwd)).toBe("needle");
+  });
+});
+
+describe("default excludes", () => {
+  test("adds configured excludes to ordinary queries", () => {
+    expect(buildQuery("src/**", "needle", undefined, cwd, defaultExcludes)).toBe(
+      "src/** !.worktrees/ !.claude/worktrees/ needle",
+    );
+  });
+
+  test("combines configured and caller excludes", () => {
+    expect(buildQuery("src/**", "needle", "test/", cwd, defaultExcludes)).toBe(
+      "src/** !.worktrees/ !.claude/worktrees/ !test/ needle",
+    );
+  });
+
+  test("does not apply an exclude when path explicitly targets it", () => {
+    expect(
+      buildQuery(".worktrees/demo/**", "needle", undefined, cwd, defaultExcludes),
+    ).toBe(".worktrees/demo/** needle");
+    expect(
+      buildQuery(".claude/worktrees/demo/**", "needle", undefined, cwd, defaultExcludes),
+    ).toBe(".claude/worktrees/demo/** needle");
   });
 });


### PR DESCRIPTION
## Summary

Fixes Pi FFF query scoping and adds configurable default excludes:

- preserves recursive directory globs like `.predibase-buildenv/**` instead of collapsing them to `.predibase-buildenv/`
- adds a `defaultExcludes` config option for path constraints that should be excluded from every `find` / `grep` query
- skips those default excludes when the query path explicitly targets one of them

## Why

The current normalization collapses `dir/**` to `dir/`. In FFF query syntax that directory-prefix constraint can match the same directory segment anywhere in the indexed tree, so a query scoped to `.predibase-buildenv/**` can also match `.worktrees/foo/.predibase-buildenv/**`.

Configurable default excludes let users avoid stale or generated subtrees, such as local git worktree roots, without baking product-specific paths into the package. Explicit searches inside those paths still work.

## Example config

```json
{
  "defaultExcludes": [".worktrees/", ".claude/worktrees/"]
}
```

## Validation

- `cd packages && bun run format:check`
- `cd packages/pi-fff && bun test`

Note: `cd packages/pi-fff && bun run typecheck` currently fails before this change on missing `@ff-labs/fff-node` type resolution plus existing implicit-any errors in `src/index.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable default exclusions for find and grep queries.
  - Queries automatically exclude configured paths unless searching within an excluded location.

- **Bug Fixes**
  - Recursive directory patterns now retain their original glob format for more precise matching.
  - Exclusion patterns are normalized consistently, improving query results for paths such as `test/**`.
 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->