### PR TITLE
fix(core): search every file when a multi-grep pattern has no bigrams

### DIFF
--- a/crates/fff-core/src/grep/grep_tests.rs
+++ b/crates/fff-core/src/grep/grep_tests.rs
@@ -518,3 +518,78 @@ fn regex_fallback_keeps_file_path_scope_issue_756() {
         "regex fallback must not leak outside the FilePath scope"
     );
 }
+
+/// Candidate bitsets are OR-ed across the patterns of a multi-pattern grep. A
+/// pattern the bigram index cannot prefilter (no printable-ASCII bigram, e.g. a
+/// CJK needle) matches any file, so leaving it out of the union hides every file
+/// that only it matches.
+#[test]
+fn multi_grep_keeps_files_for_a_pattern_without_bigrams() {
+    let dir = tempfile::tempdir().unwrap();
+    let base = crate::path_utils::canonicalize(dir.path()).unwrap();
+
+    // Only a/b/c carry the ASCII needle, so its bigrams stay below the
+    // ubiquity threshold that `compress` drops.
+    let base_contents: &[(&str, &str)] = &[
+        ("a.txt", "hello unicorn world"),
+        ("b.txt", "another unicorn line"),
+        ("c.txt", "one more unicorn here"),
+        ("d.txt", "nothing special in here"),
+        ("e.txt", "日本語のテキスト"),
+        ("f.txt", "rainbow sky above"),
+    ];
+    for (name, content) in base_contents {
+        let mut f = std::fs::File::create(base.join(name)).unwrap();
+        writeln!(f, "{}", content).unwrap();
+    }
+
+    let mut picker = FilePicker::new(FilePickerOptions {
+        base_path: base.to_str().unwrap().into(),
+        watch: false,
+        ..Default::default()
+    })
+    .unwrap();
+    picker.collect_files().unwrap();
+    assert_eq!(picker.get_files().len(), base_contents.len());
+
+    let consec_builder = BigramIndexBuilder::new(base_contents.len());
+    let skip_builder = BigramIndexBuilder::new(base_contents.len());
+    for (i, (_, content)) in base_contents.iter().enumerate() {
+        consec_builder.add_file_content(&skip_builder, i, content.as_bytes());
+    }
+    let mut index = consec_builder.compress(Some(0));
+    index.set_skip_index(skip_builder.compress(Some(0)));
+    picker.set_bigram_index(index);
+
+    let options = crate::GrepSearchOptions {
+        mode: super::GrepMode::PlainText,
+        smart_case: true,
+        page_limit: 100,
+        ..Default::default()
+    };
+
+    let matched_paths = |patterns: &[&str]| -> Vec<String> {
+        let result = picker.multi_grep(patterns, &[], &options);
+        let mut paths: Vec<String> = result
+            .files
+            .iter()
+            .map(|f| f.relative_path(&picker))
+            .collect();
+        paths.sort();
+        paths
+    };
+
+    assert_eq!(
+        matched_paths(&["unicorn", "日本語"]),
+        vec!["a.txt", "b.txt", "c.txt", "e.txt"],
+        "the CJK needle has no usable bigram, so its file must still be searched"
+    );
+
+    // Pins that the prefilter still narrows (both hold before and after):
+    // every pattern indexable => files matching none of them stay out.
+    assert_eq!(
+        matched_paths(&["unicorn", "rainbow"]),
+        vec!["a.txt", "b.txt", "c.txt", "f.txt"]
+    );
+    assert_eq!(matched_paths(&["unicorn"]), vec!["a.txt", "b.txt", "c.txt"]);
+}

--- a/crates/fff-core/src/index/candidates.rs
+++ b/crates/fff-core/src/index/candidates.rs
@@ -38,17 +38,18 @@ pub(crate) fn literal_candidates(
 
     let mut combined: Option<Vec<u64>> = None;
     for pattern in patterns {
-        if let Some(candidates) = index.query(pattern.as_bytes()) {
-            combined = Some(match combined {
-                None => candidates,
-                Some(mut acc) => {
-                    acc.iter_mut()
-                        .zip(candidates.iter())
-                        .for_each(|(a, b)| *a |= *b);
-                    acc
-                }
-            });
-        }
+        // A pattern the index can't narrow matches any file, and the union with
+        // it is every file — so bail out of prefiltering instead of dropping it.
+        let candidates = index.query(pattern.as_bytes())?;
+        combined = Some(match combined {
+            None => candidates,
+            Some(mut acc) => {
+                acc.iter_mut()
+                    .zip(candidates.iter())
+                    .for_each(|(a, b)| *a |= *b);
+                acc
+            }
+        });
     }
 
     let mut candidates = combined?;


### PR DESCRIPTION
## The defect

`ffmulti_grep` (and `FilePicker::multi_grep` / `fff_multi_grep`) reports **no
matches at all** for one of its patterns when another pattern in the same call
is indexable and the first one is not.

`literal_candidates` ORs a candidate bitset per pattern — "a file is a candidate
when it contains the bigrams of ANY pattern", as its own doc comment says — but
a pattern the index cannot answer is silently dropped from that union:

```rust
for pattern in patterns {
    if let Some(candidates) = index.query(pattern.as_bytes()) {
        combined = Some(/* OR into the accumulator */);
    }
    // no else: the pattern contributes nothing
}
```

`BigramFilter::query` returns `None` for "this pattern cannot be prefiltered —
scan everything". It does so when the pattern is shorter than 2 bytes, and when
none of its bigrams has a column, which `query`/`query_skip` both gate on
`(32..=126).contains(&b)`:

```rust
if (32..=126).contains(&prev) && (32..=126).contains(&b) {
```

So any needle without a printable-ASCII bigram pair — a CJK, Cyrillic or Greek
string, an emoji — returns `None`. Dropping it from an OR is the opposite of
conservative: the union with "every file" is every file, but the result is the
union of the *other* patterns only. Every file that matches only the dropped
pattern is never opened, so the search reports zero hits in it, silently, until
the index is rebuilt.

`grep_search`'s single-pattern call site gets this right by accident — with one
pattern `combined` stays `None` and the `combined?` below falls through to "no
prefilter". Only the multi-pattern path has somewhere to fall back *to*, and it
takes the wrong one.

## The fix

Propagate the `None` instead of skipping the pattern, matching what the single
pattern path already does. Behaviour is unchanged whenever every pattern is
indexable, and unchanged for a single pattern.

## Verification (Windows, default `ripgrep` features)

`RUSTUP_TOOLCHAIN` was pinned to `1.98.0-x86_64-pc-windows-msvc` because
`rust-toolchain.toml`'s `stable` channel could not update on this machine.

New test `multi_grep_keeps_files_for_a_pattern_without_bigrams` builds a bigram
index over six files and runs `multi_grep(["unicorn", "日本語"])`. Only `e.txt`
holds the CJK needle, and it holds no ASCII needle.

Before, `cargo test -p fff-search --lib -- multi_grep_keeps_files`:

```
test grep::grep_tests::multi_grep_keeps_files_for_a_pattern_without_bigrams ... FAILED

---- grep::grep_tests::multi_grep_keeps_files_for_a_pattern_without_bigrams stdout ----

thread 'grep::grep_tests::multi_grep_keeps_files_for_a_pattern_without_bigrams' (30068) panicked at crates\fff-core\src\grep\grep_tests.rs:582:5:
assertion `left == right` failed: the CJK needle has no usable bigram, so its file must still be searched
  left: ["a.txt", "b.txt", "c.txt"]
 right: ["a.txt", "b.txt", "c.txt", "e.txt"]

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 162 filtered out
```

After:

```
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 161 filtered out
```

The same test pins that the prefilter still narrows, so this is not a widening —
both assertions pass before and after:

- `multi_grep(["unicorn", "rainbow"])` — every pattern indexable — still returns
  exactly `a/b/c` + `f.txt`, with `d.txt` and `e.txt` filtered out.
- `multi_grep(["unicorn"])` still returns exactly `a/b/c`.

`test_multi_grep_search` is unchanged and still passes.

- `cargo test -p fff-search --lib` — 163 passed, 0 failed (baseline on unmodified
  upstream: 162 passed, 0 failed — this change adds the one new test and no
  failures).
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p fff-search --lib` — 3 warnings, identical to unmodified
  upstream (delta 0).

## CI note

`Test (windows-latest)` is red as **cancelled**, not failed — the job has no
failing step. Every other platform passes here, and the same job passed on
Windows in 10m22s on #870, which branches from the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

