### PR TITLE
fix(query-parser): stop treating dotted numbers as file-path filters

### DIFF
--- a/crates/fff-query-parser/src/constraints.rs
+++ b/crates/fff-query-parser/src/constraints.rs
@@ -63,7 +63,7 @@ impl Constraint<'_> {
             Some(dot_idx) => {
                 let extension = &filename[dot_idx + 1..];
 
-                !extension.is_empty()
+                extension.starts_with(|c: char| c.is_ascii_alphabetic())
                     && extension.len() <= 10 // just an sassumption
                     && extension.bytes().all(|b| b.is_ascii_alphanumeric())
             }

--- a/crates/fff-query-parser/src/parser.rs
+++ b/crates/fff-query-parser/src/parser.rs
@@ -1491,6 +1491,40 @@ mod tests {
     }
 
     #[test]
+    fn test_dotted_numbers_are_not_filename_constraints() {
+        fn assert_dotted_numbers_stay_text<C: ParserConfig>(config: C, label: &str) {
+            let parser = QueryParser::new(config);
+
+            for query in ["192.168.1.1 timeout", "v2.0 release", "python 3.11"] {
+                let result = parser.parse(query);
+                assert!(
+                    result.constraints.is_empty(),
+                    "{label}: {query:?} must stay search text, got {:?}",
+                    result.constraints
+                );
+            }
+
+            // Real filenames still scope the search (passes before and after).
+            assert_eq!(
+                parser.parse("schema.rs users").constraints.as_slice(),
+                [Constraint::FilePath("schema.rs")],
+                "{label}: a bare filename must still be a constraint"
+            );
+            assert_eq!(
+                parser
+                    .parse("libswscale/input.c avframe")
+                    .constraints
+                    .as_slice(),
+                [Constraint::FilePath("libswscale/input.c")],
+                "{label}: a path-prefixed filename must still be a constraint"
+            );
+        }
+
+        assert_dotted_numbers_stay_text(AiGrepConfig, "ai-grep");
+        assert_dotted_numbers_stay_text(FilenameConstraintConfig, "filename-constraint");
+    }
+
+    #[test]
     fn test_file_picker_only_one_filepath_constraint() {
         let parser = QueryParser::new(FilenameConstraintConfig);
         let result = parser.parse("main.rs score.rs");


### PR DESCRIPTION
## The defect

Grepping for a version number or an IP address scopes the search to a file path
that does not exist, so the query returns nothing of its own and falls back to
unrelated results:

```
ffgrep { pattern: "192.168.1.1 timeout" }
  -> constraints: [FilePath("192.168.1.1")]     // expected: none
```

`Constraint::is_filename_constraint_token` decides which bare tokens become a
`FilePath` scope. Its own doc comment states the rule that keeps version-like
tokens out:

```rust
// Extension must exist and look like a real file extension:
// starts with an ASCII letter (rejects version numbers like "v2.0"),
// followed by alphanumeric chars, max 10 chars total.
```

The first clause is never implemented — only the "alphanumeric" part is:

```rust
!extension.is_empty()
    && extension.len() <= 10
    && extension.bytes().all(|b| b.is_ascii_alphanumeric())
```

`v2.0` -> extension `"0"`, `192.168.1.1` -> `"1"`, `3.11` -> `"11"`. All
non-empty, all alphanumeric, so all three become `FilePath` constraints.

`test_file_picker_version_number_not_filename` was written for exactly this
("v2.0 extension starts with digit -> not a filename constraint"), but it builds
its parser from `FileSearchConfig`, where `enable_filename_constraint` is `false`
by the trait default. The token never reaches the check, so the test passes
without exercising it — and it still passes both before and after this change.

## Why it matters

`enable_filename_constraint` is on unconditionally in `AiGrepConfig`, the config
`fff-mcp`'s grep tool parses every query with, and opt-in for `:FFGrep` via
`grep.enable_filename_constraint`. Both go through `prefilter_with_filepath_retry`,
so a query scoped to a path no file has matches nothing and is then re-run
repo-wide with the scope dropped — the caller gets "0 exact matches" followed by
hits that have nothing to do with the number it searched for.

## The fix

Implement the documented first-character rule. `starts_with` on a `char`
predicate is `false` for an empty string, so it subsumes the `is_empty` check it
replaces.

## Verification (Windows, default features)

`RUSTUP_TOOLCHAIN` was pinned to `1.98.0-x86_64-pc-windows-msvc` because
`rust-toolchain.toml`'s `stable` channel could not update on this machine.

New test `test_dotted_numbers_are_not_filename_constraints` runs the same
assertions through `AiGrepConfig` and through a config with
`enable_filename_constraint` enabled, mirroring the Neovim opt-in.

Before, `cargo test -p fff-query-parser --lib -- test_dotted_numbers`:

```
test parser::tests::test_dotted_numbers_are_not_filename_constraints ... FAILED

---- parser::tests::test_dotted_numbers_are_not_filename_constraints stdout ----

thread 'parser::tests::test_dotted_numbers_are_not_filename_constraints' (21644) panicked at crates\fff-query-parser\src\parser.rs:1500:17:
ai-grep: "192.168.1.1 timeout" must stay search text, got [FilePath("192.168.1.1")]

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 89 filtered out
```

After:

```
test result: ok. 90 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

The same test pins what must not change, in both configs — these two assertions
pass before and after, so the rule only rejects digit-led extensions and does not
narrow real filenames:

- `schema.rs users` still yields `FilePath("schema.rs")`.
- `libswscale/input.c avframe` still yields `FilePath("libswscale/input.c")`.

`test_file_picker_bare_filename_constraint`,
`test_file_picker_path_prefixed_filename_constraint`,
`test_file_picker_only_one_filepath_constraint` and
`test_file_picker_version_number_not_filename` are unchanged and still pass.

- `cargo test -p fff-query-parser` — 90 lib + 3 doc tests passed, 0 failed
  (baseline on unmodified upstream: 89 lib + 3 doc, 0 failed).
- `cargo test -p fff-search --lib` — 162 passed, 0 failed.
- `cargo test -p fff-search --test grep_integration` — 68 passed, 0 failed.
- `cargo test -p fff-mcp` — 22 + 1 passed, 0 failed.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p fff-query-parser --all-targets` — no warnings, same as
  unmodified upstream (delta 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved query parsing to distinguish filenames from dotted numeric values.
  - Numeric-leading extensions and dotted-number tokens such as IP addresses, version numbers, and decimal values now remain searchable text instead of being treated as file paths.
  - Valid filenames, including extensions beginning with letters, continue to be recognized as file path constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->